### PR TITLE
Exclude test files from handler extraction

### DIFF
--- a/extract/extract-handlers.ts
+++ b/extract/extract-handlers.ts
@@ -125,7 +125,7 @@ function getAllFiles(dirPath: string, arrayOfFiles: string[] = []) {
 	files.forEach((file) => {
 		if (fs.statSync(`${dirPath}/${file}`).isDirectory()) {
 			filesArray = getAllFiles(`${dirPath}/${file}`, arrayOfFiles);
-		} else if (file.includes('.handler.') && !files.includes('.test.')) {
+		} else if (file.includes('.handler.') && !file.includes('.test.')) {
 			filesArray.push(path.join(dirPath, '/', file));
 		}
 	});

--- a/extract/extract-handlers.ts
+++ b/extract/extract-handlers.ts
@@ -125,7 +125,7 @@ function getAllFiles(dirPath: string, arrayOfFiles: string[] = []) {
 	files.forEach((file) => {
 		if (fs.statSync(`${dirPath}/${file}`).isDirectory()) {
 			filesArray = getAllFiles(`${dirPath}/${file}`, arrayOfFiles);
-		} else if (file.includes('.handler.')) {
+		} else if (file.includes('.handler.') && !files.includes('.test.')) {
 			filesArray.push(path.join(dirPath, '/', file));
 		}
 	});


### PR DESCRIPTION
This PR excludes files that include `*.test.*` from handler file extraction. Previously, we would get the following error during deploy:

```
ReferenceError: describe is not defined
    at Object.<anonymous> (/Users/bkerr/tw/pigeon/service/handlers/api/get-email-address-status/get-email-address-status.handler.test.ts:6:1)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Module.m._compile (/Users/bkerr/tw/pigeon/node_modules/ts-node/src/index.ts:1056:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/bkerr/tw/pigeon/node_modules/ts-node/src/index.ts:1059:12)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at extractHandlers (/Users/bkerr/tw/pigeon/node_modules/@faceteer/cdk/extract/extract-handlers.js:37:29)
```