### PR TITLE
Pass parsed event and handler options to authorizer

### DIFF
--- a/__tests__/handlers/api-handler.test.ts
+++ b/__tests__/handlers/api-handler.test.ts
@@ -300,6 +300,33 @@ describe('Api Handler', () => {
 		invariant(response && typeof response !== 'string' && response.body);
 		expect(JSON.parse(response.body)).toStrictEqual({ userId: userId });
 	});
+
+	test('When the authorizer function throws, it will return a 403', async () => {
+		const handler = ApiHandler(
+			{
+				method: 'GET',
+				route: '/test',
+				schemas: {},
+				authorizer: () => {
+					throw new Error('an error!!');
+				},
+			},
+			async () => {
+				return SuccessResponse({});
+			},
+		);
+
+		const response = await handler(
+			{
+				queryStringParameters: { force: true },
+			} as any,
+			{} as any,
+			() => {},
+		);
+
+		invariant(response && typeof response !== 'string' && response.body);
+		expect(response.statusCode).toBe(403);
+	});
 });
 
 export {};

--- a/handlers/api-handler.ts
+++ b/handlers/api-handler.ts
@@ -44,9 +44,15 @@ export interface ApiHandlerDefinition<B = never, Q = never, R = never>
 	};
 }
 
-export type ApiHandlerAuthorizer<B, Q, P extends ReadonlyArray<string>, A, R> = (
+export type ApiHandlerAuthorizer<
+	B,
+	Q,
+	P extends ReadonlyArray<string>,
+	A,
+	R,
+> = (
 	event: ParsedApiEvent<B, Q, P>,
-	handlerOptions: ApiHandlerOptions<B, Q, A, P, R>
+	handlerOptions: ApiHandlerOptions<B, Q, A, P, R>,
 ) => A | false;
 
 export interface ApiHandlerOptions<B, Q, A, P extends ReadonlyArray<string>, R>
@@ -69,9 +75,14 @@ export type ValidatedApiEvent<
 	};
 };
 
-export type ParsedApiEvent<B, Q, P extends ReadonlyArray<string>, A = never> = 
-	Omit<ValidatedApiEvent<B, Q, A, P>, 'input'> & 
-	{ input: Omit<ValidatedApiEvent<B, Q, A, P>['input'], 'auth'> }
+export type ParsedApiEvent<
+	B,
+	Q,
+	P extends ReadonlyArray<string>,
+	A = never,
+> = Omit<ValidatedApiEvent<B, Q, A, P>, 'input'> & {
+	input: Omit<ValidatedApiEvent<B, Q, A, P>['input'], 'auth'>;
+};
 
 export type ApiHandlerFunction<
 	B,
@@ -167,10 +178,10 @@ export function ApiHandler<
 			const parsedEvent: ParsedApiEvent<B, Q, P> = {
 				...event,
 				input: {
-					body: validatedBody,
-					query: validatedQuery,
+					body: validateBodyResult.data,
+					query: validateQueryResult.data,
 					path: validatedParameters,
-				}
+				},
 			};
 
 			let auth = undefined as unknown as A;
@@ -190,9 +201,7 @@ export function ApiHandler<
 			const validatedEvent: ValidatedApiEvent<B, Q, A, P> = {
 				...event,
 				input: {
-					body: validateBodyResult.data,
-					query: validateQueryResult.data,
-					path: validatedParameters,
+					...parsedEvent.input,
 					auth: auth,
 				},
 			};


### PR DESCRIPTION
This PR changes the API for `APIHandlerAuthorizer` functions.

Previously, the authorizer received the unparsed AWS event. If users wanted to run logic on parsed values (such as body values or path parameters), they'd have to parse it out themselves.

This adds `ParsedApiEvent` (`ValidatedApiEvent` without the `auth` property on the `input`) and the handler options as parameters to the authorizer function so that users can run logic on those values.

In order to be able to pass the parsed values to the authorizer, we have to run the body/query/path parsing before the authorizer.

I also added an `invariant` util for asserting values during tests.