### PR TITLE
Expose send to queue options

### DIFF
--- a/handlers/queue-handler.ts
+++ b/handlers/queue-handler.ts
@@ -107,6 +107,7 @@ export interface SendMessagesOptions<T> {
  */
 export type QueueSender<T> = (
 	messages: Message<T>[],
+	options?: SendMessagesOptions<T>,
 ) => Promise<QueueResults<T>>;
 
 /**
@@ -190,7 +191,7 @@ export class QueueManager {
 		sqs: SQSClient,
 		queueName: string,
 	): QueueSender<T> {
-		return (messages, options: SendMessagesOptions<T> = {}) => {
+		return (messages, options) => {
 			return this.send<T>(sqs, queueName, messages, options);
 		};
 	}

--- a/handlers/queue-handler.ts
+++ b/handlers/queue-handler.ts
@@ -82,7 +82,7 @@ export type QueueHandlerWithDefinition<T> = SQSHandler & {
 	sendMessages: (messages: Message<T>[]) => Promise<QueueResults<T>>;
 };
 
-export interface sendMessagesOptions<T> {
+export interface SendMessagesOptions<T> {
 	/**
 	 * How many parallel requests to
 	 * make to SQS at a time
@@ -190,8 +190,8 @@ export class QueueManager {
 		sqs: SQSClient,
 		queueName: string,
 	): QueueSender<T> {
-		return (messages) => {
-			return this.send<T>(sqs, queueName, messages);
+		return (messages, options: SendMessagesOptions<T> = {}) => {
+			return this.send<T>(sqs, queueName, messages, options);
 		};
 	}
 
@@ -214,7 +214,7 @@ export class QueueManager {
 			concurrentRequestLimit = 2,
 			uniqueKey,
 			randomDelay,
-		}: sendMessagesOptions<T> = {},
+		}: SendMessagesOptions<T> = {},
 	): Promise<QueueResults<T>> {
 		const uris = this.getUris(queueName);
 		const queueResults: QueueResults<T> = {


### PR DESCRIPTION
This PR exposes the `SendMessagesOptions` config object to the method returned by `generateQueueSender`. This was a previous feature of lambda handlers, but looks to have been left off in this recent version.

We will now be able to do something like:
```ts
Queues.sendEmail(messages, { randomDelay: 100 });
```