### PR TITLE
Join `defaultScopes` with defined scopes in `ApiHandler`

### DIFF
--- a/constructs/service-api-function.ts
+++ b/constructs/service-api-function.ts
@@ -98,7 +98,7 @@ export class ServiceApiFunction extends Construct {
 			authorizationScopes:
 				definition.disableAuth || authorizerType !== 'JWT'
 					? undefined
-					: definition.scopes ?? defaultScopes,
+					: [...(definition?.scopes ?? []), ...defaultScopes],
 		});
 	}
 }

--- a/handlers/api-handler.ts
+++ b/handlers/api-handler.ts
@@ -33,7 +33,7 @@ export interface ApiHandlerDefinition<B = never, Q = never, R = never>
 	 */
 	disableAuth?: boolean;
 	/**
-	 * Optional overrides of the scopes for a route
+	 * Optional scopes to add for a route
 	 */
 	scopes?: string[];
 


### PR DESCRIPTION
This is an opinionated change. 

Instead of overwriting existing scopes when defining `scopes` on an `ApiHandler`, it should instead combine them with the `defaultScopes`.

Take the use case for someone who sets the default scopes to `service:server`. The server scope should be added to every route. However, I can see the scenario where someone would set the default scope to `service:user` and then accidentally grant access to sensitive routes. 

Alternatively we can instead add a new attribute next to `defaultScopes` called something like `scopesToIncludeOnAllRoutes`... maybe I'll brainstorm a better name...