### PR TITLE
Return 400 on validation failures

### DIFF
--- a/__tests__/handlers/api-handler.test.ts
+++ b/__tests__/handlers/api-handler.test.ts
@@ -112,7 +112,7 @@ describe('Api Handler', () => {
 
 		expect(response).toBeTruthy();
 		if (response && typeof response !== 'string') {
-			expect(response.statusCode).toEqual(500);
+			expect(response.statusCode).toEqual(400);
 			const body = JSON.parse(response.body ?? '{}');
 			expect(body).toEqual({
 				instancePath: '',

--- a/__tests__/handlers/api-handler.test.ts
+++ b/__tests__/handlers/api-handler.test.ts
@@ -2,6 +2,7 @@ import { ApiHandler } from '../../handlers/api-handler';
 import { SuccessResponse } from '../../response/success-response';
 
 import { JSONSchemaType } from 'ajv';
+import { invariant } from '../../util/invariant';
 
 interface User {
 	id: string;
@@ -201,6 +202,41 @@ describe('Api Handler', () => {
 				'The API handler return an invalid response type',
 			);
 		}
+	});
+
+	test('Returns a 400 on validation failures', async () => {
+		const handler = ApiHandler(
+			{
+				method: 'PUT',
+				route: '/users/{userId}',
+				schemas: {
+					body: UserSchema,
+					response: UserSchema,
+				},
+				pathParameters: ['userId'] as const,
+			},
+			async (event) => {
+				return SuccessResponse(event.input.body);
+			},
+		);
+		const requestBody = {
+			id: '545467',
+		};
+
+		const response = await handler(
+			{
+				queryStringParameters: { force: true },
+				body: JSON.stringify(requestBody),
+				pathParameters: {
+					userId: '545467',
+				},
+			} as any,
+			{} as any,
+			() => {},
+		);
+
+		invariant(response && typeof response !== 'string');
+		expect(response.statusCode).toBe(400);
 	});
 });
 

--- a/util/invariant.test.ts
+++ b/util/invariant.test.ts
@@ -1,0 +1,20 @@
+import { invariant } from './invariant';
+
+describe('invariant', () => {
+	test('Throws an error when the condition is falsy', () => {
+		const condition = null;
+		expect(() => invariant(condition)).toThrow();
+	});
+
+	test('Asserts a condition when it is truthy', () => {
+		const result:
+			| { success: false }
+			| { success: true; data: { message: 'ok' } } = {
+			success: true,
+			data: { message: 'ok' },
+		};
+
+		invariant(result.success);
+		expect(result.data).toStrictEqual({ message: 'ok' });
+	});
+});

--- a/util/invariant.ts
+++ b/util/invariant.ts
@@ -1,0 +1,6 @@
+export function invariant(condition: unknown): asserts condition {
+	if (condition) {
+		return;
+	}
+	throw new Error('Invariant condition failed');
+}


### PR DESCRIPTION
This PR changes the error handling when there is a validation error from a JSON schema type check.

Previously, we were throwing errors inside the validate function and catching them higher up, but simply returning a generic failed response, which results in a 500.

This catches the errors, returns an object with the validation details and appropriately throws a 400 response.