### PR TITLE
Support automated package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish Package
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - 'package.json'
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Check if version has been updated
+              id: check
+              uses: EndBug/version-check@v1
+              with:
+                  diff-search: true
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Version update detected
+              if: steps.check.outputs.changed == 'true'
+              run: 'echo "Version change found! New version: ${{ steps.check.outputs.version }} (${{ steps.check.outputs.type }})"'
+
+            - name: Setup node
+              if: steps.check.outputs.changed == 'true'
+              uses: actions/setup-node@v2
+              with:
+                  node-version: '16.x'
+                  registry-url: 'https://npm.pkg.github.com'
+                  scope: '@faceteer'
+
+            - name: Installing dependencies
+              if: steps.check.outputs.changed == 'true'
+              run: npm ci
+
+            - name: Publishing package
+              if: steps.check.outputs.changed == 'true'
+              run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,16 +1,17 @@
 {
-  "[javascript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[javascriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "eslint.format.enable": true
+    "[javascript]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[typescript]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[javascriptreact]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "eslint.format.enable": true,
+    "cSpell.words": ["faceteer"]
 }


### PR DESCRIPTION
This is a solution for automating package publishing with a bias towards the developer experience. Addresses issue https://github.com/faceteer/cdk/issues/12

* Uses [EndBug/version-check@v1](https://github.com/EndBug/version-check) to determine if the version in `package.json` has changed.
* If version has changed, the workflow uses [GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) to publish the new package.

### What's required by the contributor?

All the user needs to do is change the `version` attribute in `package.json` and push it to `main` either through a commit or PR.