### PR TITLE
Add more info to `QueueHandlerDefinition` comments

### DIFF
--- a/handlers/queue-handler.ts
+++ b/handlers/queue-handler.ts
@@ -20,21 +20,30 @@ export interface QueueHandlerDefinition extends HandlerDefinition {
 	 * A name for the queue.
 	 */
 	queueName: string;
+
 	/**
-	 * The largest number of records that AWS Lambda will retrieve
-	 * from your event source at the time of invoking your function.
+	 * The largest number of records that AWS Lambda will retrieve from your event source at the time of invoking your function.
+	 *
+	 * Valid Range: Minimum value of 1. Maximum value of 10.
+	 * If `maxBatchingWindow` is configured, this value can go up to 10,000.
+	 *
+	 * @default 10
 	 */
 	batchSize?: number;
+
 	/**
-	 * The maximum amount of time in seconds  to gather records
-	 * before invoking the function.
+	 * The maximum amount of time to gather records before invoking the function.
+	 *
+	 * Valid Range: Minimum value of 0 minutes. Maximum value of 5 minutes.
+	 *
+	 * @default - no batching window. The lambda function will be invoked immediately with the records that are available.
 	 */
 	maxBatchingWindow?: number;
 
 	/**
 	 * How many times to attempt processing a message
 	 *
-	 * Default is 10
+	 * @default 10
 	 */
 	maximumAttempts?: number;
 }


### PR DESCRIPTION
A change which came up during work on another PR.

The main goal is to bring more clarity and information to the developer when configuring this handler.