### PR TITLE
Allow custom validators in `ApiHandler`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "semi": true,
+    "singleQuote": true,
+    "useTabs": true,
+    "trailingComma": "all",
+    "bracketSpacing": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,16 +1,16 @@
 {
-  "[javascript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[javascriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "eslint.format.enable": true
+	"[javascript]": {
+		"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[javascriptreact]": {
+		"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+	},
+	"[typescriptreact]": {
+		"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+	},
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"eslint.format.enable": true
 }

--- a/__tests__/extract/extract-handlers.test.ts
+++ b/__tests__/extract/extract-handlers.test.ts
@@ -1,11 +1,17 @@
 import * as path from 'path';
 import { extractHandlers } from '../../extract/extract-handlers';
 
+jest.spyOn(global.console, 'error');
+
 describe('Parse Handlers', () => {
 	test('Handlers are parsed', () => {
 		const handlers = extractHandlers(path.join(__dirname, '../../fixtures/'));
 
 		const basePath = path.join(__dirname, '../../fixtures/');
+
+		expect(console.error).toBeCalledWith(
+			`Failed to parse handler: ${basePath}api/test-bad.handler.ts`,
+		);
 
 		expect(handlers.api).toEqual({
 			'GET-users-{userId}': {
@@ -15,6 +21,7 @@ describe('Parse Handlers', () => {
 				memorySize: 512,
 				name: 'GET-users-{userId}',
 				path: `${basePath}api/test-get.handler.ts`,
+				validators: undefined,
 				schemas: {
 					body: {
 						type: 'object',
@@ -39,31 +46,10 @@ describe('Parse Handlers', () => {
 				timeout: 900,
 				name: 'POST-users',
 				path: `${basePath}api/test-post.handler.ts`,
-				schemas: {
-					body: {
-						type: 'object',
-						properties: {
-							userId: {
-								type: 'string',
-							},
-							email: {
-								type: 'string',
-							},
-						},
-						required: ['email', 'userId'],
-					},
-					response: {
-						type: 'object',
-						properties: {
-							userId: {
-								type: 'string',
-							},
-							email: {
-								type: 'string',
-							},
-						},
-						required: ['email', 'userId'],
-					},
+				schemas: undefined,
+				validators: {
+					body: expect.any(Function),
+					response: expect.any(Function),
 				},
 			},
 		});

--- a/__tests__/handlers/api-handler.test.ts
+++ b/__tests__/handlers/api-handler.test.ts
@@ -1,13 +1,18 @@
 import { ApiHandler } from '../../handlers/api-handler';
 import { SuccessResponse } from '../../response/success-response';
 
-import { JSONSchemaType } from 'ajv';
+import Ajv, { JSONSchemaType } from 'ajv';
 import { invariant } from '../../util/invariant';
 
 interface User {
 	id: string;
 	name: string;
 }
+
+const ajv = new Ajv({
+	removeAdditional: 'all',
+	coerceTypes: true,
+});
 
 const UserSchema: JSONSchemaType<User> = {
 	type: 'object',
@@ -30,7 +35,7 @@ const PutUserQuerySchema: JSONSchemaType<PutUserQuery> = {
 };
 
 describe('Api Handler', () => {
-	test('Api Handler validates', async () => {
+	test('Api Handler with schemas validates', async () => {
 		const requestBody = {
 			id: '545467',
 			name: 'jeremy',
@@ -81,7 +86,73 @@ describe('Api Handler', () => {
 		}
 	});
 
-	test('Api Handler Handles Invalid Requests', async () => {
+	test('Api Handler with schemas validates', async () => {
+		const requestBody = {
+			id: '545467',
+			name: 'jeremy',
+		};
+
+		const handler = ApiHandler(
+			{
+				method: 'PUT',
+				route: '/users/{userId}',
+				validators: {
+					body: (body) => {
+						const validate = ajv.compile(UserSchema);
+						if (!validate(body)) {
+							const [validationError] = validate.errors ?? [];
+							throw validationError;
+						} else {
+							return body;
+						}
+					},
+					query: (query) => {
+						const validate = ajv.compile(PutUserQuerySchema);
+						if (!validate(query)) {
+							const [validationError] = validate.errors ?? [];
+							throw validationError;
+						} else {
+							return query;
+						}
+					},
+				},
+				pathParameters: ['userId'] as const,
+			},
+			async (event) => {
+				const user = event.input.body;
+				const { force = false } = event.input.query;
+				expect(event.input.path.userId).toBe(requestBody.id);
+				expect(force).toBeTruthy();
+
+				return SuccessResponse(user);
+			},
+		);
+
+		const response = await handler(
+			{
+				rawQueryString: 'force=true',
+				pathParameters: {
+					userId: requestBody.id,
+				},
+				body: JSON.stringify(requestBody),
+			} as any,
+			{} as any,
+			() => {},
+		);
+
+		expect(response).toBeTruthy();
+		if (response) {
+			expect(response).toEqual({
+				body: JSON.stringify(requestBody),
+				statusCode: 200,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+			});
+		}
+	});
+
+	test('Api Handler with Schemas Handles Invalid Requests', async () => {
 		const handler = ApiHandler(
 			{
 				method: 'PUT',
@@ -123,6 +194,60 @@ describe('Api Handler', () => {
 				},
 				message: "must have required property 'id'",
 			});
+		}
+	});
+
+	test('Api Handler with Validators Handles Invalid Requests', async () => {
+		const handler = ApiHandler(
+			{
+				method: 'PUT',
+				route: '/users/{userId}',
+				validators: {
+					body: (body) => {
+						const validate = ajv.compile(UserSchema);
+						if (!validate(body)) {
+							const [validationError] = validate.errors ?? [];
+							throw validationError;
+						} else {
+							return body;
+						}
+					},
+				},
+			},
+			async (event) => {
+				const user = event.input.body;
+
+				return SuccessResponse(user);
+			},
+		);
+		const requestBody = {
+			bad: 'key',
+		};
+
+		const response = await handler(
+			{
+				queryStringParameters: { force: true },
+				body: JSON.stringify(requestBody),
+			} as any,
+			{} as any,
+			() => {},
+		);
+
+		expect(response).toBeTruthy();
+		if (response && typeof response !== 'string') {
+			expect(response.statusCode).toEqual(400);
+			const body = JSON.parse(response.body ?? '{}');
+			expect(body).toEqual({
+				instancePath: '',
+				schemaPath: '#/required',
+				keyword: 'required',
+				params: {
+					missingProperty: 'id',
+				},
+				message: "must have required property 'id'",
+			});
+		} else {
+			expect('water').toBe('wet');
 		}
 	});
 
@@ -204,7 +329,7 @@ describe('Api Handler', () => {
 		}
 	});
 
-	test('Returns a 400 on validation failures', async () => {
+	test('Returns a 400 on schema validation failures', async () => {
 		const handler = ApiHandler(
 			{
 				method: 'PUT',
@@ -237,6 +362,49 @@ describe('Api Handler', () => {
 
 		invariant(response && typeof response !== 'string');
 		expect(response.statusCode).toBe(400);
+	});
+
+	test('Returns a 400 on validator validation failures', async () => {
+		const handler = ApiHandler(
+			{
+				method: 'PUT',
+				route: '/users/{userId}',
+				validators: {
+					body: (body) => {
+						if ('name' in body && 'id' in body) {
+							return body as User;
+						} else {
+							throw new Error('Missing an attribute!');
+						}
+					},
+				},
+				pathParameters: ['userId'] as const,
+			},
+			async (event) => {
+				return SuccessResponse(event.input.body);
+			},
+		);
+		const requestBody = {
+			id: '545467',
+		};
+
+		const response = await handler(
+			{
+				queryStringParameters: { force: true },
+				body: JSON.stringify(requestBody),
+				pathParameters: {
+					userId: '545467',
+				},
+			} as any,
+			{} as any,
+			() => {},
+		);
+
+		invariant(response && typeof response !== 'string');
+		expect(response.statusCode).toBe(400);
+		expect(JSON.parse(response.body ?? '')).toEqual({
+			message: 'Missing an attribute!',
+		});
 	});
 
 	test('Authorizer rejects request when it returns false', async () => {
@@ -306,7 +474,6 @@ describe('Api Handler', () => {
 			{
 				method: 'GET',
 				route: '/test',
-				schemas: {},
 				authorizer: () => {
 					throw new Error('an error!!');
 				},

--- a/fixtures/api/test-post.handler.ts
+++ b/fixtures/api/test-post.handler.ts
@@ -1,4 +1,3 @@
-import type { JSONSchemaType } from 'ajv';
 import { ApiHandler } from '../../handlers/api-handler';
 import { SuccessResponse } from '../../response/success-response';
 
@@ -6,15 +5,6 @@ interface User {
 	userId: string;
 	email: string;
 }
-
-const UserSchema: JSONSchemaType<User> = {
-	type: 'object',
-	properties: {
-		userId: { type: 'string' },
-		email: { type: 'string' },
-	},
-	required: ['email', 'userId'],
-};
 
 export const handler = ApiHandler(
 	{
@@ -24,9 +14,9 @@ export const handler = ApiHandler(
 		memorySize: 256,
 		disableAuth: true,
 		timeout: 900,
-		schemas: {
-			body: UserSchema,
-			response: UserSchema,
+		validators: {
+			body: (body) => body as User,
+			response: (response) => response as User,
 		},
 	},
 	async (event) => {

--- a/handlers/api-handler.ts
+++ b/handlers/api-handler.ts
@@ -44,13 +44,13 @@ export interface ApiHandlerDefinition<B = never, Q = never, R = never>
 	ajv?: Ajv;
 
 	/** @deprecated Use `validators` instead */
-	schemas: {
+	schemas?: {
 		body?: JSONSchemaType<B>;
 		query?: JSONSchemaType<Q>;
 		response?: JSONSchemaType<R>;
 	};
 
-	validators: {
+	validators?: {
 		body?: (body: any) => B;
 		query?: (query: any) => Q;
 		response?: (response: any) => R;
@@ -149,11 +149,11 @@ export function ApiHandler<
 
 	const ajvValidators: AjvValidators<B, Q> = {};
 
-	if (schemas.body) {
+	if (schemas && schemas.body) {
 		ajvValidators.body = (customAjv ?? ajv).compile(schemas.body);
 	}
 
-	if (schemas.query) {
+	if (schemas && schemas.query) {
 		ajvValidators.query = (customAjv ?? ajv).compile(schemas.query);
 	}
 

--- a/handlers/api-handler.ts
+++ b/handlers/api-handler.ts
@@ -51,9 +51,9 @@ export interface ApiHandlerDefinition<B = never, Q = never, R = never>
 	};
 
 	validators?: {
-		body?: (body: any) => B;
-		query?: (query: any) => Q;
-		response?: (response: any) => R;
+		body?: (body: unknown) => B;
+		query?: (query: unknown) => Q;
+		response?: (response: unknown) => R;
 	};
 }
 

--- a/handlers/api-handler.ts
+++ b/handlers/api-handler.ts
@@ -298,9 +298,12 @@ function validateInput<T>(
 		if (validatedInput) {
 			return { success: true, data: validatedInput };
 		}
-		return { success: false, error: new Error('Input validation failed') };
+		throw new Error('Input validation failed');
 	} catch (error) {
-		return { success: false, error };
+		return {
+			success: false,
+			error: error instanceof Error ? { message: error.message } : error,
+		};
 	}
 }
 


### PR DESCRIPTION
* Deprecates `ajv` and `schemas` options inside of `ApiHandler`
* Allows `validators` to be passed in as an alternative to `schemas`
* Sets up all `AJV` logic to be wiped in next major release.
* Adds prettier settings to environment (copied from `@faceteer/facet` repo)