### PR TITLE
Fix `CronHandler` `schedule` typing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Install
         run: npm install
 
-      - name: Build
-        run: npm run build
-
       - name: Run Jest Tests
         run: npm run test:ci
         env:
@@ -50,6 +47,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ matrix.node-version }}
           AWS_DEFAULT_REGION: "us-east-1"
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Build
+        run: npm run build
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install
         run: npm install
 
+      - name: Build
+        run: npm run build
+
       - name: Run Jest Tests
         run: npm run test:ci
         env:

--- a/constructs/service-cron-function.ts
+++ b/constructs/service-cron-function.ts
@@ -62,7 +62,9 @@ export class ServiceCronFunction extends Construct {
 		 * Add the scheduled event for this cron job.
 		 */
 		const rule = new events.Rule(this, `${definition.name}Rule`, {
-			schedule: definition.schedule,
+			schedule: events.Schedule.expression(
+				definition.schedule.expressionString,
+			),
 		});
 		rule.addTarget(new eventsTargets.LambdaFunction(this.fn));
 	}

--- a/handlers/cron-handler.ts
+++ b/handlers/cron-handler.ts
@@ -4,7 +4,7 @@ import type { ScheduledHandler } from 'aws-lambda';
 
 export interface CronHandlerDefinition extends HandlerDefinition {
 	name: string;
-	schedule: Schedule;
+	schedule: Pick<Schedule, 'expressionString'>;
 }
 
 export type CronHandlerWithDefinition = ScheduledHandler & {


### PR DESCRIPTION
* Picks `expressionString` from `Schedule` type and builds schedule in CDK
* Add build step to test