### PR TITLE
Remove log group on destroy

### DIFF
--- a/constructs/service-api-function.ts
+++ b/constructs/service-api-function.ts
@@ -6,7 +6,6 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import type { HandlerNameAndPath } from '../extract/extract-handlers';
 import type { ApiHandlerDefinition } from '../handlers/api-handler';
-import { RemovalPolicy } from 'aws-cdk-lib';
 
 export interface ServiceApiFunctionProps {
 	role: iam.IRole;
@@ -71,7 +70,7 @@ export class ServiceApiFunction extends Construct {
 			layers,
 		});
 
-		this.fn.logGroup.applyRemovalPolicy(RemovalPolicy.DESTROY);
+		this.fn.logGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
 
 		this.fn.grantInvoke(apiGatewayServicePrincipal);
 

--- a/constructs/service-api-function.ts
+++ b/constructs/service-api-function.ts
@@ -6,6 +6,7 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import type { HandlerNameAndPath } from '../extract/extract-handlers';
 import type { ApiHandlerDefinition } from '../handlers/api-handler';
+import { RemovalPolicy } from 'aws-cdk-lib';
 
 export interface ServiceApiFunctionProps {
 	role: iam.IRole;
@@ -69,6 +70,8 @@ export class ServiceApiFunction extends Construct {
 			},
 			layers,
 		});
+
+		this.fn.logGroup.applyRemovalPolicy(RemovalPolicy.DESTROY);
 
 		this.fn.grantInvoke(apiGatewayServicePrincipal);
 


### PR DESCRIPTION
Sets the removal policy for an api function's log group to `DESTROY` which will destroy the log group upon stack removal.
https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-logs.LogGroup.html#removalpolicy