### PR TITLE
Require `ApiHandler` name

### DIFF
--- a/__tests__/extract/extract-handlers.test.ts
+++ b/__tests__/extract/extract-handlers.test.ts
@@ -14,13 +14,13 @@ describe('Parse Handlers', () => {
 		);
 
 		expect(handlers.api).toEqual({
-			'GET-users-{userId}': {
+			ApiGetUser: {
 				method: 'GET',
 				route: '/users/{userId}',
 				pathParameters: ['userId'],
 				description: 'Get a user',
 				memorySize: 512,
-				name: 'GET-users-{userId}',
+				name: 'ApiGetUser',
 				path: `${basePath}api/test-get.handler.ts`,
 				validators: undefined,
 				schemas: {
@@ -38,14 +38,14 @@ describe('Parse Handlers', () => {
 					},
 				},
 			},
-			'POST-users': {
+			ApiCreateUser: {
 				method: 'POST',
 				route: '/users',
 				description: 'Create a user',
 				memorySize: 256,
 				disableAuth: true,
 				timeout: 900,
-				name: 'POST-users',
+				name: 'ApiCreateUser',
 				path: `${basePath}api/test-post.handler.ts`,
 				schemas: undefined,
 				validators: {

--- a/__tests__/handlers/api-handler.test.ts
+++ b/__tests__/handlers/api-handler.test.ts
@@ -43,6 +43,7 @@ describe('Api Handler', () => {
 
 		const handler = ApiHandler(
 			{
+				name: 'putUser',
 				method: 'PUT',
 				route: '/users/{userId}',
 				schemas: {
@@ -94,6 +95,7 @@ describe('Api Handler', () => {
 
 		const handler = ApiHandler(
 			{
+				name: 'putUser',
 				method: 'PUT',
 				route: '/users/{userId}',
 				validators: {
@@ -155,6 +157,7 @@ describe('Api Handler', () => {
 	test('Api Handler with Schemas Handles Invalid Requests', async () => {
 		const handler = ApiHandler(
 			{
+				name: 'putUser',
 				method: 'PUT',
 				route: '/users/{userId}',
 				schemas: {
@@ -200,6 +203,7 @@ describe('Api Handler', () => {
 	test('Api Handler with Validators Handles Invalid Requests', async () => {
 		const handler = ApiHandler(
 			{
+				name: 'putUser',
 				method: 'PUT',
 				route: '/users/{userId}',
 				validators: {
@@ -254,6 +258,7 @@ describe('Api Handler', () => {
 	test('Api Handler Without Validator Works', async () => {
 		const handler = ApiHandler(
 			{
+				name: 'putUser',
 				method: 'PUT',
 				route: '/users/{userId}',
 				schemas: {
@@ -292,6 +297,7 @@ describe('Api Handler', () => {
 		};
 		const handler = ApiHandler(
 			{
+				name: 'putUser',
 				method: 'PUT',
 				route: '/users/{userId}',
 				schemas: {
@@ -332,6 +338,7 @@ describe('Api Handler', () => {
 	test('Returns a 400 on schema validation failures', async () => {
 		const handler = ApiHandler(
 			{
+				name: 'putUser',
 				method: 'PUT',
 				route: '/users/{userId}',
 				schemas: {
@@ -367,6 +374,7 @@ describe('Api Handler', () => {
 	test('Returns a 400 on validator validation failures', async () => {
 		const handler = ApiHandler(
 			{
+				name: 'putUser',
 				method: 'PUT',
 				route: '/users/{userId}',
 				validators: {
@@ -415,6 +423,7 @@ describe('Api Handler', () => {
 	test('Authorizer rejects request when it returns false', async () => {
 		const handler = ApiHandler(
 			{
+				name: 'getUser',
 				method: 'GET',
 				route: '/users/{userId}',
 				schemas: {},
@@ -446,6 +455,7 @@ describe('Api Handler', () => {
 
 		const handler = ApiHandler(
 			{
+				name: 'getUser',
 				method: 'GET',
 				route: '/users/{userId}',
 				schemas: {},
@@ -477,6 +487,7 @@ describe('Api Handler', () => {
 	test('When the authorizer function throws, it will return a 403', async () => {
 		const handler = ApiHandler(
 			{
+				name: 'getTest',
 				method: 'GET',
 				route: '/test',
 				authorizer: () => {

--- a/extract/extract-handlers.ts
+++ b/extract/extract-handlers.ts
@@ -54,10 +54,6 @@ export function extractHandlers(path: string) {
 						const fullDefinition: FullHandlerDefinition<ApiHandlerDefinition> =
 							{
 								...definition,
-								name: `${definition.method}${definition.route.replace(
-									/\//g,
-									'-',
-								)}`,
 								path: file,
 							};
 

--- a/extract/extract-handlers.ts
+++ b/extract/extract-handlers.ts
@@ -54,6 +54,7 @@ export function extractHandlers(path: string) {
 						const fullDefinition: FullHandlerDefinition<ApiHandlerDefinition> =
 							{
 								...definition,
+								name: pascalCase(`Api ${definition.name}`),
 								path: file,
 							};
 

--- a/fixtures/api/test-get.handler.ts
+++ b/fixtures/api/test-get.handler.ts
@@ -18,6 +18,7 @@ const UserSchema: JSONSchemaType<User> = {
 
 export const handler = ApiHandler(
 	{
+		name: 'getUser',
 		method: 'GET',
 		route: '/users/{userId}',
 		description: 'Get a user',

--- a/fixtures/api/test-post.handler.ts
+++ b/fixtures/api/test-post.handler.ts
@@ -8,6 +8,7 @@ interface User {
 
 export const handler = ApiHandler(
 	{
+		name: 'createUser',
 		method: 'POST',
 		route: '/users',
 		description: 'Create a user',

--- a/handlers/api-handler.ts
+++ b/handlers/api-handler.ts
@@ -25,6 +25,8 @@ export interface ApiHandlerDefinition<
 	R = never,
 	P extends ReadonlyArray<string> = ReadonlyArray<string>,
 > extends HandlerDefinition {
+	/** The name of the function  */
+	name: string;
 	/** HTTP method for which this function is invoked. */
 	method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 	/**


### PR DESCRIPTION
Lambda functions are currently being named by the api route. This makes debugging annoying when trying to find the lambda or its associated log in AWS.

This change will now require `name` to be specified when defining an `ApiHandler`.