### PR TITLE
Fix log group creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,5 +160,9 @@ response/**/*.js
 response/**/*.d.ts
 __tests__/**/*.js
 __tests__/**/*.d.ts
+client/**/*.js
+client/**/*.d.ts
+util/**/*.js
+util/**/*.d.ts
 index.js
 index.d.ts

--- a/constructs/service-api-function.ts
+++ b/constructs/service-api-function.ts
@@ -3,6 +3,7 @@ import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambdaNodeJs from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import type { HandlerNameAndPath } from '../extract/extract-handlers';
 import type { ApiHandlerDefinition } from '../handlers/api-handler';
@@ -70,7 +71,10 @@ export class ServiceApiFunction extends Construct {
 			layers,
 		});
 
-		this.fn.logGroup.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+		new logs.LogGroup(this, 'LogGroup', {
+			logGroupName: `/aws/lambda/${this.fn.functionName}`,
+			removalPolicy: cdk.RemovalPolicy.DESTROY,
+		});
 
 		this.fn.grantInvoke(apiGatewayServicePrincipal);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faceteer/cdk",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "CDK 2.0 constructs and helpers that make composing a Lambda powered service easier.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
In the latest version, we were unable to deploy a stack because when a lambda is formed. This is because the log group isn't created until invocation. Therefore, we were not able reference the associated log group to add removal policy.

To fix this, I am creating the log group immediately and assigning it a removal policy.