### PR TITLE
Support greedy path parameters

### DIFF
--- a/constructs/lambda-service.ts
+++ b/constructs/lambda-service.ts
@@ -198,12 +198,14 @@ export class LambdaService extends Construct implements iam.IGrantable {
 			/**
 			 * Validate that `pathParameters` and `route` are consistent
 			 */
-			const regex = /\{[a-zA-Z_$0-9]+\}/g;
+			const regex = /\{[a-zA-Z_$0-9+]+\}/g;
 			const pathParameters = [...(apiHandler.pathParameters ?? [])];
 			const routeParameters =
 				apiHandler.route
 					.match(regex)
-					?.map((param) => param.substring(1, param.length - 1)) ?? [];
+					?.map((param) =>
+						param.substring(1, param.length - 1).replace('+', ''),
+					) ?? [];
 			pathParameters.sort();
 			routeParameters.sort();
 			if (JSON.stringify(pathParameters) !== JSON.stringify(routeParameters)) {

--- a/constructs/lambda-service.ts
+++ b/constructs/lambda-service.ts
@@ -16,6 +16,7 @@ import { ServiceNotificationFunction } from './service-notification-function';
 import { ServiceQueueFunction } from './service-queue-function';
 import { ServiceCronFunction } from './service-cron-function';
 import { ServiceEventFunction } from './service-event-function';
+import { validatePathParameters } from '../util/validate-path-parameters';
 
 export interface LambdaServiceProps {
 	handlersFolder: string;
@@ -198,21 +199,9 @@ export class LambdaService extends Construct implements iam.IGrantable {
 			/**
 			 * Validate that `pathParameters` and `route` are consistent
 			 */
-			const regex = /\{[a-zA-Z_$0-9+]+\}/g;
-			const pathParameters = [...(apiHandler.pathParameters ?? [])];
-			const routeParameters =
-				apiHandler.route
-					.match(regex)
-					?.map((param) =>
-						param.substring(1, param.length - 1).replace('+', ''),
-					) ?? [];
-			pathParameters.sort();
-			routeParameters.sort();
-			if (JSON.stringify(pathParameters) !== JSON.stringify(routeParameters)) {
-				throw new Error(
-					`The Api Handler definition in "${apiHandler.path}" does not have properly configured path parameters`,
-				);
-			}
+			validatePathParameters(apiHandler.route, [
+				...(apiHandler.pathParameters ?? []),
+			]);
 			/**
 			 * Add a new function to the API
 			 */

--- a/util/validate-path-parameters.test.ts
+++ b/util/validate-path-parameters.test.ts
@@ -1,0 +1,41 @@
+import {
+	getParametersFromRoute,
+	validatePathParameters,
+} from './validate-path-parameters';
+
+describe('validate-path-parameters', () => {
+	test('getParametersFromRoute', () => {
+		expect(getParametersFromRoute('/users')).toEqual([]);
+		expect(getParametersFromRoute('/users/{userId}')).toEqual(['userId']);
+		expect(getParametersFromRoute('/users/{userId}/posts')).toEqual(['userId']);
+		expect(getParametersFromRoute('/users/{userId}/posts/{postId}')).toEqual([
+			'userId',
+			'postId',
+		]);
+		expect(getParametersFromRoute('/users/{userId}/posts/{postId+}')).toEqual([
+			'userId',
+			'postId',
+		]);
+	});
+
+	test('validatePathParameters', () => {
+		expect(() => validatePathParameters('/users', [])).not.toThrow();
+		expect(() =>
+			validatePathParameters('/users/{userId}', ['userId']),
+		).not.toThrow();
+		expect(() =>
+			validatePathParameters('/users/{userId}/posts', ['userId']),
+		).not.toThrow();
+		expect(() =>
+			validatePathParameters('/users/{userId}/posts/{postId}', [
+				'postId',
+				'userId',
+			]),
+		).not.toThrow();
+
+		expect(() =>
+			validatePathParameters('/users/{userId}/posts/{postId}', ['postId']),
+		).toThrow();
+		expect(() => validatePathParameters('/users', ['userId'])).toThrow();
+	});
+});

--- a/util/validate-path-parameters.ts
+++ b/util/validate-path-parameters.ts
@@ -1,0 +1,21 @@
+const regex = /\{[a-zA-Z_$0-9+]+\}/g;
+
+export const getParametersFromRoute = (route: string) => {
+	const matched = route.match(regex);
+	if (!matched) return [];
+	const params = matched.map((param) =>
+		param.substring(1, param.length - 1).replace('+', ''),
+	);
+	return params;
+};
+
+export const validatePathParameters = (route: string, parameters: string[]) => {
+	const routeParameters = getParametersFromRoute(route);
+	routeParameters.sort();
+	parameters.sort();
+	if (JSON.stringify(routeParameters) !== JSON.stringify(parameters)) {
+		throw new Error(
+			`The Api route ${route} does not have properly configured path parameters`,
+		);
+	}
+};


### PR DESCRIPTION
https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-routes.html

Fixes build failure when path parameter was greedy.