### PR TITLE
Default query object to `{}` before validation

### DIFF
--- a/handlers/api-handler.ts
+++ b/handlers/api-handler.ts
@@ -187,7 +187,7 @@ export function ApiHandler<
 				);
 			}
 
-			let queryBody: unknown;
+			let queryBody = {};
 			if (event.rawQueryString) {
 				try {
 					queryBody = qs.parse(event.rawQueryString);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faceteer/cdk",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "CDK 2.0 constructs and helpers that make composing a Lambda powered service easier.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Some validators such as AJV and Zod will fail validation if the schema expects an `object` but received `undefined`.

One way around this would be to set the entirety of the query object as "optional", but then you get some typescript errors for the common spreading pattern because `query` could be undefined:
<img width="1007" alt="Screen Shot 2022-07-13 at 6 06 33 PM" src="https://user-images.githubusercontent.com/11020347/178851864-11c3735b-0fff-42d2-b859-e92395412dae.png">

