### PR TITLE
Add support for FIFO queues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,12 @@ module.exports = {
 		'valid-jsdoc': 'off',
 		semi: 'off',
 		'no-unused-vars': 'off',
-		'@typescript-eslint/no-unused-vars': 'error',
+		'@typescript-eslint/no-unused-vars': [
+			'error',
+			{
+				argsIgnorePattern: '^_',
+			},
+		],
 		'no-dupe-class-members': 'off',
 		'new-cap': 'off',
 		'prettier/prettier': [

--- a/__tests__/extract/extract-handlers.test.ts
+++ b/__tests__/extract/extract-handlers.test.ts
@@ -65,6 +65,15 @@ describe('Parse Handlers', () => {
 				name: 'QueueUpdateUser',
 				path: `${basePath}queue/test-queue.handler.ts`,
 			},
+			QueueCreateUser: {
+				queueName: 'createUser',
+				memorySize: 1024,
+				timeout: 900,
+				isFifoQueue: true,
+				maximumAttempts: 10,
+				name: 'QueueUpdateUser',
+				path: `${basePath}queue/test-fifo-queue.handler.ts`,
+			},
 		});
 
 		expect(handlers.cron).toEqual({

--- a/__tests__/extract/extract-handlers.test.ts
+++ b/__tests__/extract/extract-handlers.test.ts
@@ -62,7 +62,7 @@ describe('Parse Handlers', () => {
 				timeout: 900,
 				isFifoQueue: true,
 				maximumAttempts: 10,
-				name: 'QueueUpdateUser',
+				name: 'QueueCreateUser',
 				path: `${basePath}queue/test-fifo-queue.handler.ts`,
 			},
 			QueueUpdateUser: {

--- a/__tests__/extract/extract-handlers.test.ts
+++ b/__tests__/extract/extract-handlers.test.ts
@@ -56,15 +56,6 @@ describe('Parse Handlers', () => {
 		});
 
 		expect(handlers.queue).toEqual({
-			QueueUpdateUser: {
-				queueName: 'updateUser',
-				memorySize: 1024,
-				timeout: 900,
-				maxBatchingWindow: 10,
-				maximumAttempts: 10,
-				name: 'QueueUpdateUser',
-				path: `${basePath}queue/test-queue.handler.ts`,
-			},
 			QueueCreateUser: {
 				queueName: 'createUser',
 				memorySize: 1024,
@@ -73,6 +64,15 @@ describe('Parse Handlers', () => {
 				maximumAttempts: 10,
 				name: 'QueueUpdateUser',
 				path: `${basePath}queue/test-fifo-queue.handler.ts`,
+			},
+			QueueUpdateUser: {
+				queueName: 'updateUser',
+				memorySize: 1024,
+				timeout: 900,
+				maxBatchingWindow: 10,
+				maximumAttempts: 10,
+				name: 'QueueUpdateUser',
+				path: `${basePath}queue/test-queue.handler.ts`,
 			},
 		});
 

--- a/constructs/service-queue-function.ts
+++ b/constructs/service-queue-function.ts
@@ -48,6 +48,7 @@ export class ServiceQueueFunction extends Construct {
 			retentionPeriod: cdk.Duration.days(14),
 			receiveMessageWaitTime: cdk.Duration.seconds(20),
 			visibilityTimeout: timeout,
+			fifo: definition.isFifoQueue,
 		});
 
 		this.dlq.grantSendMessages(role);
@@ -57,6 +58,7 @@ export class ServiceQueueFunction extends Construct {
 			retentionPeriod: cdk.Duration.days(14),
 			receiveMessageWaitTime: cdk.Duration.seconds(20),
 			visibilityTimeout: timeout,
+			fifo: definition.isFifoQueue,
 			deadLetterQueue: {
 				maxReceiveCount: maximumAttempts,
 				queue: this.dlq,

--- a/fixtures/queue/test-fifo-queue.handler.ts
+++ b/fixtures/queue/test-fifo-queue.handler.ts
@@ -1,0 +1,26 @@
+import { QueueHandler } from '../../handlers/queue-handler';
+import { SQSClient } from '@aws-sdk/client-sqs';
+
+interface User {
+	userId: string;
+	email: string;
+}
+
+export const handler = QueueHandler(
+	{
+		queueName: 'createUser',
+		memorySize: 1024,
+		timeout: 900,
+		isFifoQueue: true,
+
+		sqs: new SQSClient({ region: 'us-east-1' }),
+		validator: (body: any) => {
+			return body as User;
+		},
+	},
+	async (event) => {
+		return {
+			retry: event.ValidMessages,
+		};
+	},
+);

--- a/handlers/message.ts
+++ b/handlers/message.ts
@@ -1,4 +1,6 @@
-export interface Message<T> {
+export type Message<T> = StandardMessage<T> | FifoMessage<T>;
+
+export interface StandardMessage<T> {
 	/**
 	 * The validated message body
 	 */
@@ -9,21 +11,48 @@ export interface Message<T> {
 	attempts: number;
 }
 
+export interface FifoMessage<T> {
+	/**
+	 * The validated message body
+	 */
+	body: T;
+	/**
+	 * How many times this message has bee
+	 */
+	attempts: number;
+
+	/**
+	 * The tag that specifies that a message belongs to a specific message group.
+	 * https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html#API_SendMessage_RequestParameters
+	 */
+	groupId: string;
+
+	/**
+	 * The token used for deduplication of sent messages.
+	 * https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html#API_SendMessage_RequestParameters
+	 */
+	deduplicationId?: string;
+}
+
+export const isFifoMessage = <T>(
+	message: Message<T>,
+): message is FifoMessage<T> => 'groupId' in message;
+
 /**
  * A message that has been validated
  */
-export interface ValidatedMessage<T> extends Message<T> {
+export type ValidatedMessage<T> = Message<T> & {
 	/**
 	 * Id of the SQS record containing the
 	 * message that's used for retrying messages
 	 */
 	messageId: string;
-}
+};
 
 /**
  * A message that has permanently failed to process
  */
-export interface FailedMessage extends Message<unknown> {
+export type FailedMessage = Message<unknown> & {
 	/**
 	 * Id of the record containing the
 	 * message that's used for retrying messages
@@ -33,9 +62,9 @@ export interface FailedMessage extends Message<unknown> {
 	 * The error thrown when trying to validate a message
 	 */
 	error: unknown;
-}
+};
 
-export interface InvalidMessage extends Message<unknown> {
+export type InvalidMessage = Message<unknown> & {
 	/**
 	 * Id of the record containing the
 	 * message that's used for retrying messages
@@ -45,4 +74,4 @@ export interface InvalidMessage extends Message<unknown> {
 	 * The error thrown when trying to validate a message
 	 */
 	error: unknown;
-}
+};


### PR DESCRIPTION
Adds support for AWS's [FIFO queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html)

## Usage

### QueueHandler
Define your `QueueHandler` as a FIFO queue by adding the `isFifoQueue` attribute.
```ts
export const handler = QueueHandler(
	{
		queueName: 'createUser',
		memorySize: 1024,
		timeout: 900,
		isFifoQueue: true,

		sqs: new SQSClient({ region: 'us-east-1' }),
		validator: (body: any) => {
			return body as User;
		},
	},
	async (event) => {	},
);
```

### Queuing messages
When generating the queuer function, there now exists a new option `{ isFifoQueue: boolean }` which will tell typescript what kind of message it expects.

![Screen Shot 2022-10-19 at 6 09 22 PM](https://user-images.githubusercontent.com/11020347/196821227-ffe390e9-bdb2-4085-a1e4-31a703ba1a68.png)

![Screen Shot 2022-10-19 at 6 09 50 PM](https://user-images.githubusercontent.com/11020347/196821287-90636f9b-232a-455b-af9a-bd9696ab2c90.png)