### PR TITLE
Allow event bus to be referenced by a key

### DIFF
--- a/__tests__/extract/extract-handlers.test.ts
+++ b/__tests__/extract/extract-handlers.test.ts
@@ -83,6 +83,7 @@ describe('Parse Handlers', () => {
 				eventPattern: {
 					detailType: ['Some user was added type'],
 				},
+				eventBusName: 'event-bus-name',
 				memorySize: 1024,
 				timeout: 900,
 				path: `${basePath}event/test-event.handler.ts`,

--- a/__tests__/handlers/event-handler.test.ts
+++ b/__tests__/handlers/event-handler.test.ts
@@ -27,6 +27,7 @@ describe('Event Handler', () => {
 			{
 				name: 'test-event',
 				eventPattern: { detailType: ['test'] },
+				eventBusName: 'event-bus-name',
 				validator: (body) => {
 					return body as EventBridgeEvent<string, AddedUserEvent>;
 				},
@@ -54,6 +55,7 @@ describe('Event Handler', () => {
 				eventPattern: {
 					detailType: ['test'],
 				},
+				eventBusName: 'event-bus-name',
 				validator: (detail) => {
 					if ('userId' in detail && 'token' in detail) {
 						return detail as EventBridgeEvent<string, AddedUserEvent>;

--- a/constructs/lambda-service.ts
+++ b/constructs/lambda-service.ts
@@ -46,7 +46,7 @@ export interface LambdaServiceProps {
 		route53Zone?: route53.IHostedZone;
 	};
 	/**
-	 * Use the key to reference the appropriate event bus in your Queue Handler definition.
+	 * Use the key to reference the appropriate event bus in your Event Handler definition.
 	 */
 	eventBuses?: { [key: string]: events.IEventBus };
 }

--- a/constructs/lambda-service.ts
+++ b/constructs/lambda-service.ts
@@ -257,10 +257,7 @@ export class LambdaService extends Construct implements iam.IGrantable {
 			}
 
 			let eventBus: events.IEventBus;
-			if (!eventHandler.eventBusName) {
-				// Default to first event bus if not specified in handler
-				eventBus = Object.values(eventBuses)[0];
-			} else if (eventBuses[eventHandler.eventBusName]) {
+			if (eventBuses[eventHandler.eventBusName]) {
 				// Treated `eventBusName` as a key to reference configured event buses
 				eventBus = eventBuses[eventHandler.eventBusName];
 			} else {

--- a/fixtures/event/test-event.handler.ts
+++ b/fixtures/event/test-event.handler.ts
@@ -12,6 +12,7 @@ export const handler = EventHandler(
 		eventPattern: {
 			detailType: ['Some user was added type'],
 		},
+		eventBusName: 'event-bus-name',
 		memorySize: 1024,
 		timeout: 900,
 		validator: (body) => {

--- a/handlers/event-handler.ts
+++ b/handlers/event-handler.ts
@@ -10,9 +10,8 @@ export interface EventHandlerDefinition extends HandlerDefinition {
 
 	/**
 	 * Uses event bus name that is provided and configured within stack.
-	 * If no name is specified, the first bus listed in the CDK configuration is used.
 	 */
-	eventBusName?: string;
+	eventBusName: string;
 
 	/**
 	 * The event pattern in which to subscribe to.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@faceteer/cdk",
-	"version": "3.4.5",
+	"version": "3.5.0",
 	"description": "CDK 2.0 constructs and helpers that make composing a Lambda powered service easier.",
 	"main": "index.js",
 	"files": [


### PR DESCRIPTION
There was some feedback where the way to communicate the event bus to use to the Event Handler was a little too complex because the developer needed to create an environmental variable of the event bus names to pass them into the event handler. 

Instead, this will allow the previous pattern AND a way to reference the event bus by a set key decided by the developer.

## Usage

### Configuring LambdaService
```ts
export enum EventBus {
	UserBus = 'user-bus',
}

const service = new faceteer.LambdaService(this, 'LambdaService', {
	handlersFolder: path.join(__dirname, '../../service/'),
	domain: { ... },
	jwtAuthorizer: { ... },
	eventBuses: { [EventBus.UserBus]: userEventBus }, // now a map instead of array
});
```

### Configuring EventHandler
```ts
export const handler = EventHandler(
	{
		name: 'UserAddedEvent',
		eventBus: EventBus.UserBus, // using same enum defined above
		eventPattern: { detailType: ['Some user was added type'] },
		validator: (body) => { },
	},
	async (event) => { },
);
```