### PR TITLE
Breaking/override logical

### DIFF
--- a/__mocks__/naming-conflict/v1/naming-conflict.handler.ts
+++ b/__mocks__/naming-conflict/v1/naming-conflict.handler.ts
@@ -1,0 +1,36 @@
+import { ApiHandler } from '../../../handlers/api-handler';
+import { SuccessResponse } from '../../../response/success-response';
+import type { JSONSchemaType } from 'ajv';
+
+interface User {
+	userId: string;
+	email: string;
+}
+
+const UserSchema: JSONSchemaType<User> = {
+	type: 'object',
+	properties: {
+		userId: { type: 'string' },
+		email: { type: 'string' },
+	},
+	required: ['email', 'userId'],
+};
+
+export const handler = ApiHandler(
+	{
+		name: 'getUser',
+		method: 'GET',
+		route: '/users/{userId}',
+		description: 'Get a user',
+		memorySize: 512,
+		schemas: {
+			body: UserSchema,
+		},
+		pathParameters: ['userId'],
+	},
+	async (event) => {
+		console.log(event);
+
+		return SuccessResponse({ success: 'true' });
+	},
+);

--- a/__mocks__/naming-conflict/v2/naming-conflict-2.handler.ts
+++ b/__mocks__/naming-conflict/v2/naming-conflict-2.handler.ts
@@ -1,0 +1,36 @@
+import { ApiHandler } from '../../../handlers/api-handler';
+import { SuccessResponse } from '../../../response/success-response';
+import type { JSONSchemaType } from 'ajv';
+
+interface User {
+	userId: string;
+	email: string;
+}
+
+const UserSchema: JSONSchemaType<User> = {
+	type: 'object',
+	properties: {
+		userId: { type: 'string' },
+		email: { type: 'string' },
+	},
+	required: ['email', 'userId'],
+};
+
+export const handler = ApiHandler(
+	{
+		name: 'getUser',
+		method: 'GET',
+		route: '/user/{userId}',
+		description: 'Get a user',
+		memorySize: 512,
+		schemas: {
+			body: UserSchema,
+		},
+		pathParameters: ['userId'],
+	},
+	async (event) => {
+		console.log(event);
+
+		return SuccessResponse({ success: 'true' });
+	},
+);

--- a/__mocks__/override-logical-ids/override-logical-ids.handler.ts
+++ b/__mocks__/override-logical-ids/override-logical-ids.handler.ts
@@ -1,0 +1,43 @@
+import { ApiHandler } from '../../handlers/api-handler';
+import { SuccessResponse } from '../../response/success-response';
+import type { JSONSchemaType } from 'ajv';
+
+interface User {
+	userId: string;
+	email: string;
+}
+
+const UserSchema: JSONSchemaType<User> = {
+	type: 'object',
+	properties: {
+		userId: { type: 'string' },
+		email: { type: 'string' },
+	},
+	required: ['email', 'userId'],
+};
+
+export const handler = ApiHandler(
+	{
+		name: 'getUser',
+		method: 'GET',
+		route: '/users/{userId}',
+		description: 'Get a user',
+		memorySize: 512,
+		schemas: {
+			body: UserSchema,
+		},
+		pathParameters: ['userId'],
+		cfnOverrides: {
+			logicalIds: {
+				function: 'GetUsersByIdFn',
+				route: 'GETusersByIdRoute',
+				integration: 'GETusersByIdIntegration',
+			},
+		},
+	},
+	async (event) => {
+		console.log(event);
+
+		return SuccessResponse({ success: 'true' });
+	},
+);

--- a/__mocks__/renaming/v1/rename-get.handler.ts
+++ b/__mocks__/renaming/v1/rename-get.handler.ts
@@ -1,0 +1,36 @@
+import { ApiHandler } from '../../../handlers/api-handler';
+import { SuccessResponse } from '../../../response/success-response';
+import type { JSONSchemaType } from 'ajv';
+
+interface User {
+	userId: string;
+	email: string;
+}
+
+const UserSchema: JSONSchemaType<User> = {
+	type: 'object',
+	properties: {
+		userId: { type: 'string' },
+		email: { type: 'string' },
+	},
+	required: ['email', 'userId'],
+};
+
+export const handler = ApiHandler(
+	{
+		name: 'renamedGetUser',
+		method: 'GET',
+		route: '/users/{userId}',
+		description: 'Get a user',
+		memorySize: 512,
+		schemas: {
+			body: UserSchema,
+		},
+		pathParameters: ['userId'],
+	},
+	async (event) => {
+		console.log(event);
+
+		return SuccessResponse({ success: 'true' });
+	},
+);

--- a/__mocks__/renaming/v2/rename-get-2.handler.ts
+++ b/__mocks__/renaming/v2/rename-get-2.handler.ts
@@ -1,0 +1,36 @@
+import { ApiHandler } from '../../../handlers/api-handler';
+import { SuccessResponse } from '../../../response/success-response';
+import type { JSONSchemaType } from 'ajv';
+
+interface User {
+	userId: string;
+	email: string;
+}
+
+const UserSchema: JSONSchemaType<User> = {
+	type: 'object',
+	properties: {
+		userId: { type: 'string' },
+		email: { type: 'string' },
+	},
+	required: ['email', 'userId'],
+};
+
+export const handler = ApiHandler(
+	{
+		name: 'renamedGetUser2',
+		method: 'GET',
+		route: '/users/{userId}',
+		description: 'Get a user',
+		memorySize: 512,
+		schemas: {
+			body: UserSchema,
+		},
+		pathParameters: ['userId'],
+	},
+	async (event) => {
+		console.log(event);
+
+		return SuccessResponse({ success: 'true' });
+	},
+);

--- a/__tests__/extract/extract-handlers.test.ts
+++ b/__tests__/extract/extract-handlers.test.ts
@@ -9,10 +9,6 @@ describe('Parse Handlers', () => {
 
 		const basePath = path.join(__dirname, '../../fixtures/');
 
-		expect(console.error).toBeCalledWith(
-			`Failed to parse handler: ${basePath}api/test-bad.handler.ts`,
-		);
-
 		expect(handlers.api).toEqual({
 			ApiGetUser: {
 				method: 'GET',
@@ -22,6 +18,30 @@ describe('Parse Handlers', () => {
 				memorySize: 512,
 				name: 'ApiGetUser',
 				path: `${basePath}api/test-get.handler.ts`,
+				validators: undefined,
+				schemas: {
+					body: {
+						type: 'object',
+						properties: {
+							userId: {
+								type: 'string',
+							},
+							email: {
+								type: 'string',
+							},
+						},
+						required: ['email', 'userId'],
+					},
+				},
+			},
+			ApiGetUsere3a216: {
+				method: 'GET',
+				route: '/other-users/{userId}',
+				pathParameters: ['userId'],
+				description: 'Get some other user',
+				memorySize: 512,
+				name: 'ApiGetUsere3a216',
+				path: `${basePath}api/test-is-duplicate.handler.ts`,
 				validators: undefined,
 				schemas: {
 					body: {

--- a/__tests__/infrastructure/api-handler.test.ts
+++ b/__tests__/infrastructure/api-handler.test.ts
@@ -1,0 +1,96 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { ExampleApiStack } from './lib/example-api-stack';
+import path from 'path';
+
+jest.spyOn(global.console, 'error');
+
+describe('ApiLogicalIds', () => {
+	test('Renaming a Lambda function should not change the logical id of its route or api gateway integration', () => {
+		const app = new App();
+		const app2 = new App();
+		const v1Path = path.join(
+			path.resolve(__dirname),
+			'../../__mocks__/renaming/v1',
+		);
+		const v2Path = path.join(
+			path.resolve(__dirname),
+			'../../__mocks__/renaming/v2',
+		);
+
+		const stackv1 = new ExampleApiStack(app, 'ApiStack', {
+			handlerPath: v1Path,
+		});
+
+		const stackv2 = new ExampleApiStack(app2, 'ApiStack', {
+			handlerPath: v2Path,
+		});
+
+		const template1 = Template.fromStack(stackv1);
+		const template2 = Template.fromStack(stackv2);
+
+		const Lambdav1Integration = template1.findResources(
+			'AWS::ApiGatewayV2::Integration',
+			{},
+		);
+		const Lambdav2Integration = template2.findResources(
+			'AWS::ApiGatewayV2::Integration',
+			{},
+		);
+
+		const Lambdav1Route = template1.findResources(
+			'AWS::ApiGatewayV2::Route',
+			{},
+		);
+		const Lambdav2Route = template2.findResources(
+			'AWS::ApiGatewayV2::Route',
+			{},
+		);
+
+		const logicalId = (r: Record<string, any>) => Object.keys(r)[0];
+
+		expect(logicalId(Lambdav1Integration)).toEqual(
+			logicalId(Lambdav2Integration),
+		);
+		expect(logicalId(Lambdav1Route)).toEqual(logicalId(Lambdav2Route));
+	});
+
+	test('Lambdas with the same name but different routes should not conflict', () => {
+		const app = new App();
+		const app2 = new App();
+		const v1Path = path.join(
+			path.resolve(__dirname),
+			'../../__mocks__/naming-conflict/v1',
+		);
+		const v2Path = path.join(
+			path.resolve(__dirname),
+			'../../__mocks__/naming-conflict/v2',
+		);
+
+		const stackv1 = new ExampleApiStack(app, 'ApiStack', {
+			handlerPath: v1Path,
+		});
+
+		const stackv2 = new ExampleApiStack(app2, 'ApiStack', {
+			handlerPath: v2Path,
+		});
+
+		const template1 = Template.fromStack(stackv1);
+		const template2 = Template.fromStack(stackv2);
+
+		const Lambdav1Route = template1.findResources(
+			'AWS::ApiGatewayV2::Route',
+			{},
+		);
+		const Lambdav2Route = template2.findResources(
+			'AWS::ApiGatewayV2::Route',
+			{},
+		);
+
+		const logicalId = (r: Record<string, any>) => Object.keys(r)[0];
+
+		expect(logicalId(Lambdav1Route)).not.toEqual(logicalId(Lambdav2Route));
+	});
+});
+
+export {};

--- a/__tests__/infrastructure/bin/example-api.ts
+++ b/__tests__/infrastructure/bin/example-api.ts
@@ -1,0 +1,7 @@
+import * as cdk from 'aws-cdk-lib';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const app = new cdk.App();
+
+// Stacks are intentionally not created here -- this application isn't meant to
+// be deployed.

--- a/__tests__/infrastructure/infrastructure.test.ts
+++ b/__tests__/infrastructure/infrastructure.test.ts
@@ -1,0 +1,32 @@
+import path from 'path';
+import { LambdaService } from '../../constructs';
+import { Construct } from 'constructs';
+import { App, Stack } from 'aws-cdk-lib';
+import { EventBus } from 'aws-cdk-lib/aws-events';
+
+class ExampleStack extends Stack {
+	readonly service: LambdaService;
+
+	constructor(scope: Construct, id: string) {
+		super(scope, id);
+
+		const basePath = path.join(__dirname, '../../fixtures/');
+
+		this.service = new LambdaService(this, 'ExampleService', {
+			handlersFolder: basePath,
+			eventBuses: {
+				'event-bus-name': new EventBus(this, 'ExampleBus'),
+			},
+		});
+	}
+}
+
+const app = new App();
+
+describe('Create Service', () => {
+	test('All expected handlers exist', () => {
+		const stack = new ExampleStack(app, 'ExampleStack');
+
+		expect(stack.service.functions).toHaveLength(7);
+	});
+});

--- a/__tests__/infrastructure/lib/example-api-stack.ts
+++ b/__tests__/infrastructure/lib/example-api-stack.ts
@@ -1,0 +1,24 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { EventBus } from 'aws-cdk-lib/aws-events';
+import { Construct } from 'constructs';
+import { LambdaService } from '../../../constructs';
+
+interface P extends StackProps {
+	handlerPath: string;
+}
+
+export class ExampleApiStack extends Stack {
+	readonly service: LambdaService;
+	constructor(scope: Construct, id: string, props: P) {
+		super(scope, id, props);
+
+		this.service = new LambdaService(this, 'HelloWorld', {
+			handlersFolder: props.handlerPath,
+			eventBuses: {
+				foobar: new EventBus(this, 'testEB', {
+					eventBusName: 'foobar',
+				}),
+			},
+		});
+	}
+}

--- a/__tests__/util/route-to-alphanumeric.test.ts
+++ b/__tests__/util/route-to-alphanumeric.test.ts
@@ -1,0 +1,35 @@
+import { routeToAlphaNumeric } from '../../util/route-to-alphanumeric';
+
+describe('route-to-alphanumeric', () => {
+	it('Should strip out / characters', () => {
+		const route = '/foo/bar';
+		expect(routeToAlphaNumeric(route)).not.toContain('/');
+	});
+
+	it('Should strip out {} characters', () => {
+		const route = '/foo/{bar}';
+		expect(routeToAlphaNumeric(route)).not.toContain('{');
+		expect(routeToAlphaNumeric(route)).not.toContain('}');
+	});
+
+	it('Should strip out space characters', () => {
+		const route = 'GET /foo/bar';
+		expect(routeToAlphaNumeric(route)).not.toContain(' ');
+	});
+
+	it('should have distinct results for unique routes', () => {
+		const routeA = 'GET /foo/bar';
+		const routeB = 'POST /foo/bar';
+		const routeC = 'GET /foobar';
+		const routeD = 'GET /foo/{bar}';
+
+		const expectToBeDifferent = (a: string, b: string) =>
+			routeToAlphaNumeric(a) !== routeToAlphaNumeric(b);
+		expectToBeDifferent(routeA, routeB);
+		expectToBeDifferent(routeA, routeC);
+		expectToBeDifferent(routeA, routeD);
+		expectToBeDifferent(routeC, routeD);
+	});
+});
+
+export {};

--- a/constructs/base-function.ts
+++ b/constructs/base-function.ts
@@ -1,0 +1,95 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambdaNodeJs from 'aws-cdk-lib/aws-lambda-nodejs';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import { Construct } from 'constructs';
+import type { FullHandlerDefinition } from '../extract/extract-handlers';
+import { LambdaServiceProps } from './lambda-service';
+import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
+import { HandlerDefinition } from '../handlers/handler';
+
+export interface BaseFunctionProps<T extends HandlerDefinition> {
+	role: iam.IRole;
+	definition: FullHandlerDefinition<T>;
+	bundlingOptions?: lambdaNodeJs.BundlingOptions;
+	layers?: lambda.ILayerVersion[];
+	defaults?: LambdaServiceProps['defaults'];
+	network?: {
+		vpc: IVpc;
+		vpcSubnets?: SubnetSelection;
+		securityGroups?: ISecurityGroup[];
+	};
+	environment?: { [key: string]: string };
+}
+
+export class BaseFunction<
+	T extends HandlerDefinition,
+> extends lambdaNodeJs.NodejsFunction {
+	readonly definition: FullHandlerDefinition<T>;
+	readonly timeout: cdk.Duration;
+
+	constructor(
+		scope: Construct,
+		id: string,
+		{
+			role,
+			definition,
+			bundlingOptions = {},
+			layers,
+			defaults,
+			network,
+			environment,
+		}: BaseFunctionProps<T>,
+	) {
+		const useVpc = definition.vpc ?? defaults?.vpc ?? false;
+		if (useVpc && network === undefined) {
+			throw new Error(
+				'Function is defined to use VPC, but no VPC has been provided for service.',
+			);
+		}
+		const timeout = cdk.Duration.seconds(
+			definition.timeout ?? defaults?.timeout ?? 30,
+		);
+
+		super(scope, id, {
+			awsSdkConnectionReuse: true,
+			entry: definition.path,
+			description: definition.description,
+			memorySize: definition.memorySize ?? defaults?.memorySize ?? 192,
+			reservedConcurrentExecutions: definition.reservedConcurrentExecutions,
+			allowAllOutbound: definition.allowAllOutbound,
+			allowPublicSubnet: definition.allowPublicSubnet,
+			timeout,
+			role,
+			bundling: {
+				sourceMap: true,
+				sourceMapMode: lambdaNodeJs.SourceMapMode.INLINE,
+				...bundlingOptions,
+			},
+			environment: {
+				NODE_OPTIONS: '--enable-source-maps',
+				HANDLER_NAME: definition.name,
+				ACCOUNT_ID: cdk.Fn.ref('AWS::AccountId'),
+				...environment,
+			},
+			layers,
+			vpc: useVpc ? network?.vpc : undefined,
+			vpcSubnets: useVpc ? network?.vpcSubnets : undefined,
+			securityGroups: useVpc ? network?.securityGroups : undefined,
+		});
+
+		this.definition = definition;
+		this.timeout = timeout;
+
+		const logRetention =
+			definition.logRetention ?? defaults?.logRetention ?? 'destroy';
+		new logs.LogGroup(this, 'LogGroup', {
+			logGroupName: `/aws/lambda/${this.functionName}`,
+			removalPolicy:
+				logRetention === 'destroy'
+					? cdk.RemovalPolicy.DESTROY
+					: cdk.RemovalPolicy.RETAIN,
+		});
+	}
+}

--- a/constructs/lambda-service.ts
+++ b/constructs/lambda-service.ts
@@ -28,6 +28,8 @@ import {
 	LambdaAuthorizerConfig,
 } from './api-gateway';
 import { CfnAuthorizer } from 'aws-cdk-lib/aws-apigatewayv2';
+import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
+import { BaseFunctionProps } from './base-function';
 
 export interface LambdaServiceProps {
 	/** The path to the folder where the handlers are stored.
@@ -71,10 +73,37 @@ export interface LambdaServiceProps {
 		identitySource: string[];
 		enableSimpleResponses?: boolean;
 	};
+	/** The default options that will apply to all handlers.
+	 *
+	 * These options apply to all handlers.
+	 * They can be overridden in the handler configuration itself.
+	 */
 	defaults?: {
-		scopes: string[];
-		memorySize: number;
-		timeout: number;
+		scopes?: string[];
+		memorySize?: number;
+		timeout?: number;
+		vpc?: boolean;
+		logRetention?: 'destroy' | 'retain';
+	};
+	/** VPC, subnet, and security groups for the lambda functions.
+	 *
+	 * If provided, all functions will be created in the VPC by default. You can
+	 * override that by setting `vpc: false`, either globally in {@link defaults}
+	 * or per-function in the function handler definition.
+	 */
+	network?: {
+		/** The VPC that the Lambda handlers should run in. */
+		vpc: IVpc;
+		/** The VPC subnets that the Lambda handlers should run in.
+		 *
+		 * If undefined, the Vpc default strategy is used.
+		 */
+		vpcSubnets?: SubnetSelection;
+		/** The security groups that apply to the Lambda handlers.
+		 *
+		 * If undefined,
+		 */
+		securityGroups?: ISecurityGroup[];
 	};
 	/** @deprecated Use `defaults.scopes` */
 	defaultScopes?: string[];
@@ -121,12 +150,23 @@ export class LambdaService extends Construct implements iam.IGrantable {
 			eventBuses,
 			api,
 			stage,
+			layers,
+			network,
 		}: LambdaServiceProps,
 	) {
 		super(scope, id);
 
 		this.environmentVariables.set('NODE_OPTIONS', '--enable-source-maps');
 		this.environmentVariables.set('ACCOUNT_ID', cdk.Fn.ref('AWS::AccountId'));
+
+		if (network && defaults?.vpc === undefined) {
+			// If a VPC is supplied, then enable VPC use for functions by default. It
+			// could be an easy mistake to add a VPC but not enable its usage.
+			defaults = {
+				...defaults,
+				vpc: true,
+			};
+		}
 
 		if (!role) {
 			/**
@@ -220,6 +260,15 @@ export class LambdaService extends Construct implements iam.IGrantable {
 			}
 		}
 
+		/** Function props shared by all functions. Just add definition and any handler-specific props! */
+		const baseFunctionProps: Omit<BaseFunctionProps<never>, 'definition'> = {
+			role,
+			bundlingOptions,
+			layers,
+			defaults,
+			network,
+		};
+
 		/**
 		 * Create all of the API handlers
 		 */
@@ -234,15 +283,13 @@ export class LambdaService extends Construct implements iam.IGrantable {
 			 * Add a new function to the API
 			 */
 			const apiFn = new ServiceApiFunction(this, apiHandler.name, {
+				...baseFunctionProps,
+				defaultScopes,
 				definition: apiHandler,
 				httpApi: this.api,
-				role,
 				authorizer: this.authorizer,
-				bundlingOptions,
-				defaultScopes,
-				defaults,
 			});
-			this.functions.push(apiFn.fn);
+			this.functions.push(apiFn);
 		}
 
 		for (const queueHandler of Object.values(handlers.queue)) {
@@ -250,11 +297,10 @@ export class LambdaService extends Construct implements iam.IGrantable {
 			 * Create the queue handlers and their respective queues
 			 */
 			const queueFn = new ServiceQueueFunction(this, queueHandler.name, {
-				role,
+				...baseFunctionProps,
 				definition: queueHandler,
-				bundlingOptions,
 			});
-			this.functions.push(queueFn.fn);
+			this.functions.push(queueFn);
 			this.queues.set(queueFn.definition.queueName, queueFn);
 
 			this.environmentVariables.set(
@@ -294,12 +340,11 @@ export class LambdaService extends Construct implements iam.IGrantable {
 			}
 
 			const eventFn = new ServiceEventFunction(this, eventHandler.name, {
-				role,
+				...baseFunctionProps,
 				definition: eventHandler,
-				bundlingOptions,
 				eventBus,
 			});
-			this.functions.push(eventFn.fn);
+			this.functions.push(eventFn);
 		}
 
 		for (const notificationHandler of Object.values(handlers.notification)) {
@@ -321,14 +366,13 @@ export class LambdaService extends Construct implements iam.IGrantable {
 				this,
 				notificationHandler.name,
 				{
+					...baseFunctionProps,
 					definition: notificationHandler,
-					role,
 					topic,
-					bundlingOptions,
 				},
 			);
 
-			this.functions.push(notificationFn.fn);
+			this.functions.push(notificationFn);
 		}
 
 		for (const cronHandler of Object.values(handlers.cron)) {
@@ -336,12 +380,11 @@ export class LambdaService extends Construct implements iam.IGrantable {
 			 * Create cron handlers
 			 */
 			const cronFn = new ServiceCronFunction(this, cronHandler.name, {
+				...baseFunctionProps,
 				definition: cronHandler,
-				role,
-				bundlingOptions,
 			});
 
-			this.functions.push(cronFn.fn);
+			this.functions.push(cronFn);
 		}
 
 		/**

--- a/constructs/service-api-function.ts
+++ b/constructs/service-api-function.ts
@@ -70,7 +70,7 @@ export class ServiceApiFunction extends BaseFunction<ApiHandlerDefinition> {
 
 		this.integration.overrideLogicalId(
 			definition.cfnOverrides?.logicalIds?.integration ??
-				`ServiceApiIntegration${definition.method}${routeToAlphaNumeric(
+				`ApiIntegration${definition.method}${routeToAlphaNumeric(
 					definition.route,
 				)}`,
 		);
@@ -93,9 +93,7 @@ export class ServiceApiFunction extends BaseFunction<ApiHandlerDefinition> {
 		});
 		this.route.overrideLogicalId(
 			definition.cfnOverrides?.logicalIds?.route ??
-				`ServiceApiRoute${definition.method}${routeToAlphaNumeric(
-					definition.route,
-				)}`,
+				`ApiRoute${definition.method}${routeToAlphaNumeric(definition.route)}`,
 		);
 	}
 }

--- a/constructs/service-api-function.ts
+++ b/constructs/service-api-function.ts
@@ -66,6 +66,10 @@ export class ServiceApiFunction extends BaseFunction<ApiHandlerDefinition> {
 			payloadFormatVersion: '2.0',
 		});
 
+		integration.overrideLogicalId(
+			`ServiceApiIntegration-${definition.method}-${definition.route}`,
+		);
+
 		this.route = new apigwv2.CfnRoute(this, `Route`, {
 			apiId: httpApi.ref,
 			routeKey: `${definition.method} ${definition.route}`,
@@ -77,5 +81,8 @@ export class ServiceApiFunction extends BaseFunction<ApiHandlerDefinition> {
 					? undefined
 					: definition.scopes ?? defaults?.scopes ?? defaultScopes,
 		});
+		this.route.overrideLogicalId(
+			`ServiceApiRoute-${definition.method}-${definition.route}`,
+		);
 	}
 }

--- a/constructs/service-cron-function.ts
+++ b/constructs/service-cron-function.ts
@@ -1,71 +1,37 @@
-import * as cdk from 'aws-cdk-lib';
 import * as events from 'aws-cdk-lib/aws-events';
 import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
-import * as iam from 'aws-cdk-lib/aws-iam';
-import * as lambdaNodeJs from 'aws-cdk-lib/aws-lambda-nodejs';
-import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
-import type { FullHandlerDefinition } from '../extract/extract-handlers';
 import { CronHandlerDefinition } from '../handlers';
+import { BaseFunction, BaseFunctionProps } from './base-function';
 
-export interface ServiceCronFunctionProps {
-	role: iam.IRole;
-	definition: FullHandlerDefinition<CronHandlerDefinition>;
-	bundlingOptions?: lambdaNodeJs.BundlingOptions;
-	layers?: lambda.ILayerVersion[];
-}
+export interface ServiceCronFunctionProps
+	extends BaseFunctionProps<CronHandlerDefinition> {}
 
-export class ServiceCronFunction extends Construct {
-	readonly fn: lambdaNodeJs.NodejsFunction;
+export class ServiceCronFunction extends BaseFunction<CronHandlerDefinition> {
+	readonly rule: events.Rule;
 
-	constructor(
-		scope: Construct,
-		id: string,
-		{
-			role,
-			definition,
-			bundlingOptions = {},
-			layers,
-		}: ServiceCronFunctionProps,
-	) {
-		super(scope, id);
-
-		const timeout = definition.timeout
-			? cdk.Duration.seconds(definition.timeout)
-			: cdk.Duration.seconds(60);
-
-		/**
-		 * Create the lambda function
-		 */
-		this.fn = new lambdaNodeJs.NodejsFunction(this, 'Function', {
-			role: role,
-			awsSdkConnectionReuse: true,
-			entry: definition.path,
-			description: definition.description,
-			allowAllOutbound: definition.allowAllOutbound,
-			memorySize: definition.memorySize ?? 256,
-			timeout: timeout,
-			bundling: {
-				...bundlingOptions,
-				sourceMap: true,
-				sourceMapMode: lambdaNodeJs.SourceMapMode.INLINE,
+	constructor(scope: Construct, id: string, props: ServiceCronFunctionProps) {
+		const { definition, defaults } = props;
+		super(scope, id, {
+			...props,
+			defaults: {
+				timeout: 60,
+				...defaults,
 			},
 			environment: {
-				NODE_OPTIONS: '--enable-source-maps',
-				HANDLER_NAME: definition.name,
 				DD_TAGS: `handler_type:cron,handler_name:${definition.name}`,
+				...props.environment,
 			},
-			layers,
 		});
 
 		/**
 		 * Add the scheduled event for this cron job.
 		 */
-		const rule = new events.Rule(this, `${definition.name}Rule`, {
+		this.rule = new events.Rule(this, `${definition.name}Rule`, {
 			schedule: events.Schedule.expression(
 				definition.schedule.expressionString,
 			),
+			targets: [new eventsTargets.LambdaFunction(this)],
 		});
-		rule.addTarget(new eventsTargets.LambdaFunction(this.fn));
 	}
 }

--- a/constructs/service-event-function.ts
+++ b/constructs/service-event-function.ts
@@ -1,77 +1,35 @@
-import * as cdk from 'aws-cdk-lib';
-import * as iam from 'aws-cdk-lib/aws-iam';
-import * as lambdaNodeJs from 'aws-cdk-lib/aws-lambda-nodejs';
-import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as events from 'aws-cdk-lib/aws-events';
 import * as eventTargets from 'aws-cdk-lib/aws-events-targets';
 import { Construct } from 'constructs';
-import type { FullHandlerDefinition } from '../extract/extract-handlers';
 import { EventHandlerDefinition } from '../handlers';
+import { BaseFunction, BaseFunctionProps } from './base-function';
 
-export interface ServiceEventFunctionProps {
-	role: iam.IRole;
-	definition: FullHandlerDefinition<EventHandlerDefinition>;
-	bundlingOptions?: lambdaNodeJs.BundlingOptions;
-	layers?: lambda.ILayerVersion[];
+export interface ServiceEventFunctionProps
+	extends BaseFunctionProps<EventHandlerDefinition> {
 	eventBus: events.IEventBus;
 }
 
-export class ServiceEventFunction extends Construct {
-	readonly fn: lambdaNodeJs.NodejsFunction;
-	readonly definition: FullHandlerDefinition<EventHandlerDefinition>;
+export class ServiceEventFunction extends BaseFunction<EventHandlerDefinition> {
+	readonly rule: events.Rule;
 
-	constructor(
-		scope: Construct,
-		id: string,
-		{
-			role,
-			definition,
-			bundlingOptions,
-			layers,
-			eventBus,
-		}: ServiceEventFunctionProps,
-	) {
-		super(scope, id);
-
-		const timeout = definition.timeout
-			? cdk.Duration.seconds(definition.timeout)
-			: cdk.Duration.seconds(60);
-
-		this.definition = definition;
-
-		const sharedFunctionProps: lambdaNodeJs.NodejsFunctionProps = {
-			role: role,
-			awsSdkConnectionReuse: true,
-			entry: definition.path,
-			description: definition.description,
-			allowAllOutbound: definition.allowAllOutbound,
-			allowPublicSubnet: definition.allowPublicSubnet,
-			memorySize: definition.memorySize ?? 256,
-			timeout: timeout,
-			bundling: {
-				...bundlingOptions,
-				sourceMap: true,
-				sourceMapMode: lambdaNodeJs.SourceMapMode.INLINE,
+	constructor(scope: Construct, id: string, props: ServiceEventFunctionProps) {
+		const { definition, defaults, eventBus } = props;
+		super(scope, id, {
+			...props,
+			defaults: {
+				timeout: 60,
+				...defaults,
 			},
 			environment: {
-				NODE_OPTIONS: '--enable-source-maps',
-				HANDLER_NAME: definition.name,
-				ACCOUNT_ID: cdk.Fn.ref('AWS::AccountId'),
 				DD_TAGS: `handler_type:queue,handler_name:${definition.name}`,
+				...props.environment,
 			},
-			layers,
-		};
+		});
 
-		this.fn = new lambdaNodeJs.NodejsFunction(
-			this,
-			'Function',
-			sharedFunctionProps,
-		);
-
-		new events.Rule(this, 'Rule', {
+		this.rule = new events.Rule(this, 'Rule', {
 			eventBus,
 			eventPattern: definition.eventPattern,
-			targets: [new eventTargets.LambdaFunction(this.fn)],
+			targets: [new eventTargets.LambdaFunction(this)],
 		});
 	}
 }

--- a/constructs/service-queue-function.ts
+++ b/constructs/service-queue-function.ts
@@ -1,39 +1,34 @@
 import * as cdk from 'aws-cdk-lib';
-import * as iam from 'aws-cdk-lib/aws-iam';
-import * as lambdaNodeJs from 'aws-cdk-lib/aws-lambda-nodejs';
-import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as lambdaEventSources from 'aws-cdk-lib/aws-lambda-event-sources';
 import { constantCase } from 'constant-case';
 import { Construct } from 'constructs';
-import type { FullHandlerDefinition } from '../extract/extract-handlers';
 import { QueueHandlerDefinition } from '../handlers/queue-handler';
+import { BaseFunction, BaseFunctionProps } from './base-function';
 
-export interface ServiceQueueFunctionProps {
-	role: iam.IRole;
-	definition: FullHandlerDefinition<QueueHandlerDefinition>;
-	bundlingOptions?: lambdaNodeJs.BundlingOptions;
-	layers?: lambda.ILayerVersion[];
-}
+export interface ServiceQueueFunctionProps
+	extends BaseFunctionProps<QueueHandlerDefinition> {}
 
-export class ServiceQueueFunction extends Construct {
-	readonly fn: lambdaNodeJs.NodejsFunction;
+export class ServiceQueueFunction extends BaseFunction<QueueHandlerDefinition> {
 	readonly queue: sqs.Queue;
 	readonly dlq: sqs.Queue;
 	readonly queueEnvironmentVariable: string;
 	readonly dlqEnvironmentVariable: string;
-	readonly definition: FullHandlerDefinition<QueueHandlerDefinition>;
+	readonly eventSource: lambdaEventSources.SqsEventSource;
 
-	constructor(
-		scope: Construct,
-		id: string,
-		{ role, definition, bundlingOptions, layers }: ServiceQueueFunctionProps,
-	) {
-		super(scope, id);
-
-		const timeout = definition.timeout
-			? cdk.Duration.seconds(definition.timeout)
-			: cdk.Duration.seconds(60);
+	constructor(scope: Construct, id: string, props: ServiceQueueFunctionProps) {
+		const { role, defaults, definition } = props;
+		super(scope, id, {
+			...props,
+			defaults: {
+				timeout: 60,
+				...defaults,
+			},
+			environment: {
+				DD_TAGS: `handler_type:queue,handler_name:${definition.name}`,
+				...props.environment,
+			},
+		});
 
 		const maximumAttempts = definition.maximumAttempts ?? 10;
 
@@ -42,12 +37,10 @@ export class ServiceQueueFunction extends Construct {
 		)}`;
 		this.dlqEnvironmentVariable = `DLQ_${constantCase(definition.queueName)}`;
 
-		this.definition = definition;
-
 		this.dlq = new sqs.Queue(this, `Dlq`, {
 			retentionPeriod: cdk.Duration.days(14),
 			receiveMessageWaitTime: cdk.Duration.seconds(20),
-			visibilityTimeout: timeout,
+			visibilityTimeout: this.timeout,
 		});
 
 		this.dlq.grantSendMessages(role);
@@ -56,7 +49,7 @@ export class ServiceQueueFunction extends Construct {
 		this.queue = new sqs.Queue(this, 'Queue', {
 			retentionPeriod: cdk.Duration.days(14),
 			receiveMessageWaitTime: cdk.Duration.seconds(20),
-			visibilityTimeout: timeout,
+			visibilityTimeout: this.timeout,
 			deadLetterQueue: {
 				maxReceiveCount: maximumAttempts,
 				queue: this.dlq,
@@ -66,43 +59,13 @@ export class ServiceQueueFunction extends Construct {
 		this.queue.grantSendMessages(role);
 		this.queue.grantConsumeMessages(role);
 
-		const sharedFunctionProps: lambdaNodeJs.NodejsFunctionProps = {
-			role: role,
-			awsSdkConnectionReuse: true,
-			entry: definition.path,
-			description: definition.description,
-			allowAllOutbound: definition.allowAllOutbound,
-			allowPublicSubnet: definition.allowPublicSubnet,
-			memorySize: definition.memorySize ?? 256,
-			timeout: timeout,
-			bundling: {
-				...bundlingOptions,
-				sourceMap: true,
-				sourceMapMode: lambdaNodeJs.SourceMapMode.INLINE,
-			},
-			environment: {
-				NODE_OPTIONS: '--enable-source-maps',
-				HANDLER_NAME: definition.name,
-				ACCOUNT_ID: cdk.Fn.ref('AWS::AccountId'),
-				DD_TAGS: `handler_type:queue,handler_name:${definition.name}`,
-			},
-			layers,
-		};
-
-		this.fn = new lambdaNodeJs.NodejsFunction(
-			this,
-			'Function',
-			sharedFunctionProps,
-		);
-
-		this.fn.addEventSource(
-			new lambdaEventSources.SqsEventSource(this.queue, {
-				batchSize: definition.batchSize,
-				maxBatchingWindow: definition.maxBatchingWindow
-					? cdk.Duration.seconds(definition.maxBatchingWindow)
-					: undefined,
-				reportBatchItemFailures: true,
-			}),
-		);
+		this.eventSource = new lambdaEventSources.SqsEventSource(this.queue, {
+			batchSize: definition.batchSize,
+			maxBatchingWindow: definition.maxBatchingWindow
+				? cdk.Duration.seconds(definition.maxBatchingWindow)
+				: undefined,
+			reportBatchItemFailures: true,
+		});
+		this.addEventSource(this.eventSource);
 	}
 }

--- a/fixtures/api/test-bad.handler.ts
+++ b/fixtures/api/test-bad.handler.ts
@@ -1,3 +1,0 @@
-export function thisIsNotRight() {
-	return null;
-}

--- a/fixtures/api/test-is-duplicate.handler.ts
+++ b/fixtures/api/test-is-duplicate.handler.ts
@@ -1,0 +1,37 @@
+import { ApiHandler } from '../../handlers/api-handler';
+import { SuccessResponse } from '../../response/success-response';
+import type { JSONSchemaType } from 'ajv';
+
+interface User {
+	userId: string;
+	email: string;
+}
+
+const UserSchema: JSONSchemaType<User> = {
+	type: 'object',
+	properties: {
+		userId: { type: 'string' },
+		email: { type: 'string' },
+	},
+	required: ['email', 'userId'],
+};
+
+export const handler = ApiHandler(
+	{
+		// The name is duplicated with `test-get.handler.ts`
+		name: 'getUser',
+		method: 'GET',
+		route: '/other-users/{userId}',
+		description: 'Get some other user',
+		memorySize: 512,
+		schemas: {
+			body: UserSchema,
+		},
+		pathParameters: ['userId'],
+	},
+	async (event) => {
+		console.log(event);
+
+		return SuccessResponse({ success: 'true' });
+	},
+);

--- a/handlers/api-handler.ts
+++ b/handlers/api-handler.ts
@@ -73,6 +73,16 @@ export interface ApiHandlerDefinition<
 		query?: (query: unknown) => Q;
 		response?: (response: unknown) => R;
 	};
+	/**
+	 * Overrides for the generated cloudformation resources. If you don't know what this is, check out [this doc](https://docs.aws.amazon.com/cdk/v2/guide/identifiers.html)
+	 */
+	cfnOverrides?: {
+		logicalIds?: {
+			function?: string;
+			route?: string;
+			integration?: string;
+		};
+	};
 }
 
 export type ApiHandlerAuthorizer<

--- a/handlers/handler.ts
+++ b/handlers/handler.ts
@@ -39,6 +39,13 @@ export interface HandlerDefinition {
 	 * Attach the lambda function to the VPC
 	 */
 	vpc?: boolean;
+	/**
+	 * Should function logs be destroyed if the function itself is removed.
+	 *
+	 * This is 'destroy' by default, but you may wish to pick 'keep' so logs can
+	 * be audited even after the function is deleted.
+	 */
+	logRetention?: 'destroy' | 'retain';
 }
 
 /**

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,7 +2,12 @@ export default {
 	preset: 'ts-jest',
 	testEnvironment: 'node',
 	reporters: ['default', 'jest-junit'],
-	testPathIgnorePatterns: ['^.+\\.js$', '/fixtures/'],
+	testPathIgnorePatterns: [
+		'^.+\\.js$',
+		'/fixtures/',
+		'^.+\\.d\\.ts$',
+		'^.+/infrastructure/(bin|lib)/',
+	],
 	coveragePathIgnorePatterns: ['/fixtures/'],
 	globals: {
 		'ts-jest': {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,7 +4,7 @@ export default {
 	reporters: ['default', 'jest-junit'],
 	testPathIgnorePatterns: [
 		'^.+\\.js$',
-     '/__mocks__/',
+     	'/__mocks__/',
 		'/fixtures/',
 		'^.+\\.d\\.ts$',
 		'^.+/infrastructure/(bin|lib)/',

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,7 @@ export default {
 	reporters: ['default', 'jest-junit'],
 	testPathIgnorePatterns: [
 		'^.+\\.js$',
+     '/__mocks__/',
 		'/fixtures/',
 		'^.+\\.d\\.ts$',
 		'^.+/infrastructure/(bin|lib)/',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@faceteer/cdk",
-	"version": "3.5.0",
+	"version": "3.6.0",
 	"description": "CDK 2.0 constructs and helpers that make composing a Lambda powered service easier.",
 	"main": "index.js",
 	"files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     "isolatedModules": true,
     "types": ["jest", "node"]
   },
-  "exclude": ["node_modules", "./node.d.ts", "jest.config.ts", "./__tests__/"]
+  "exclude": ["node_modules", "./node.d.ts", "jest.config.ts", "./__tests__/", "./fixtures", "./__mocks__"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     "isolatedModules": true,
     "types": ["jest", "node"]
   },
-  "exclude": ["node_modules", "./node.d.ts", "jest.config.ts"]
+  "exclude": ["node_modules", "./node.d.ts", "jest.config.ts", "./__tests__/"]
 }

--- a/util/route-to-alphanumeric.ts
+++ b/util/route-to-alphanumeric.ts
@@ -1,0 +1,25 @@
+/**
+ * Takes a route string, such as /users/{userId}/emails and removes non-alphanumeric characters, attempting to maintain string-uniqueness.
+ * Since we DO want this to change if the actual route were to change, this addition of the "hash" in the logical id should be safe IN THIS CASE.
+ *  This just helps us avoid cases where you'd end up with the same logical id otherwise, like /foo/bar and /foobar or /foo/{bar}.
+ * @param route
+ */
+export const routeToAlphaNumeric = (route: string): string => {
+	return `${route}${hashString(route).toString(16)}`.replace(
+		// match all non-alphanumeric characters
+		/[^A-Za-z0-9]/g,
+		'',
+	);
+};
+
+/**
+ * Function found on stackoverflow that generates a 32 bit integer hash for our string
+ * @param s
+ * @returns
+ */
+function hashString(s: string) {
+	let h: number = 0;
+	for (let i = 0; i < s.length; i++)
+		h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
+	return h;
+}


### PR DESCRIPTION
Okay, so Issue #38 is caused when the api handler definition changes its logical id, when the user-chosen name changes.

This fixes that problem by making the "LogicalId" of the route and integration pieces created be based on the "route" key instead of the user-given name. This will not affect the ACTUAL name seen in the AWS console, only that used by cloudformation to identify the given architecture pieces.

I also added the ability to override these new logical ids with custom values, which should provide an upgrade path (by way of copying your logical id for that function out of the existing deployment in cloudformation and adding it to your deploy code)