### PR TITLE
Support Arm64 architecture in Lambda handlers

### DIFF
--- a/constructs/base-function.ts
+++ b/constructs/base-function.ts
@@ -77,6 +77,7 @@ export class BaseFunction<
 			vpc: useVpc ? network?.vpc : undefined,
 			vpcSubnets: useVpc ? network?.vpcSubnets : undefined,
 			securityGroups: useVpc ? network?.securityGroups : undefined,
+			architecture: definition.architecture ?? defaults?.architecture,
 		});
 
 		this.definition = definition;

--- a/constructs/base-function.ts
+++ b/constructs/base-function.ts
@@ -8,6 +8,7 @@ import type { FullHandlerDefinition } from '../extract/extract-handlers';
 import { LambdaServiceProps } from './lambda-service';
 import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
 import { HandlerDefinition } from '../handlers/handler';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
 
 export interface BaseFunctionProps<T extends HandlerDefinition> {
 	role: iam.IRole;
@@ -51,6 +52,8 @@ export class BaseFunction<
 		const timeout = cdk.Duration.seconds(
 			definition.timeout ?? defaults?.timeout ?? 30,
 		);
+		const architecture: 'x86_64' | 'arm64' =
+			definition.architecture ?? defaults?.architecture ?? 'x86_64';
 
 		super(scope, id, {
 			awsSdkConnectionReuse: true,
@@ -77,7 +80,8 @@ export class BaseFunction<
 			vpc: useVpc ? network?.vpc : undefined,
 			vpcSubnets: useVpc ? network?.vpcSubnets : undefined,
 			securityGroups: useVpc ? network?.securityGroups : undefined,
-			architecture: definition.architecture ?? defaults?.architecture,
+			architecture:
+				architecture === 'x86_64' ? Architecture.X86_64 : Architecture.ARM_64,
 		});
 
 		this.definition = definition;

--- a/constructs/lambda-service.ts
+++ b/constructs/lambda-service.ts
@@ -30,6 +30,7 @@ import {
 import { CfnAuthorizer } from 'aws-cdk-lib/aws-apigatewayv2';
 import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
 import { BaseFunctionProps } from './base-function';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
 
 export interface LambdaServiceProps {
 	/** The path to the folder where the handlers are stored.
@@ -84,6 +85,7 @@ export interface LambdaServiceProps {
 		timeout?: number;
 		vpc?: boolean;
 		logRetention?: 'destroy' | 'retain';
+		architecture?: Architecture;
 	};
 	/** VPC, subnet, and security groups for the lambda functions.
 	 *

--- a/constructs/lambda-service.ts
+++ b/constructs/lambda-service.ts
@@ -30,7 +30,6 @@ import {
 import { CfnAuthorizer } from 'aws-cdk-lib/aws-apigatewayv2';
 import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
 import { BaseFunctionProps } from './base-function';
-import { Architecture } from 'aws-cdk-lib/aws-lambda';
 
 export interface LambdaServiceProps {
 	/** The path to the folder where the handlers are stored.
@@ -85,7 +84,7 @@ export interface LambdaServiceProps {
 		timeout?: number;
 		vpc?: boolean;
 		logRetention?: 'destroy' | 'retain';
-		architecture?: Architecture;
+		architecture?: 'x86_64' | 'arm64';
 	};
 	/** VPC, subnet, and security groups for the lambda functions.
 	 *

--- a/handlers/handler.ts
+++ b/handlers/handler.ts
@@ -1,3 +1,4 @@
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import type { Context } from 'aws-lambda';
 
 /**
@@ -46,6 +47,14 @@ export interface HandlerDefinition {
 	 * be audited even after the function is deleted.
 	 */
 	logRetention?: 'destroy' | 'retain';
+	/** The CPU architecture to use for this handler.
+	 *
+	 * Uses {@link Architecture.X86_64} by default. Changing to
+	 * {@link Architecture.ARM_64} will reduce costs, but node packages that rely
+	 * on native components may not work without additional effort as they will
+	 * have to be compiled for Arm.
+	 */
+	architecture?: Architecture;
 }
 
 /**

--- a/handlers/handler.ts
+++ b/handlers/handler.ts
@@ -1,4 +1,3 @@
-import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import type { Context } from 'aws-lambda';
 
 /**
@@ -49,12 +48,11 @@ export interface HandlerDefinition {
 	logRetention?: 'destroy' | 'retain';
 	/** The CPU architecture to use for this handler.
 	 *
-	 * Uses {@link Architecture.X86_64} by default. Changing to
-	 * {@link Architecture.ARM_64} will reduce costs, but node packages that rely
-	 * on native components may not work without additional effort as they will
-	 * have to be compiled for Arm.
+	 * Uses `x86_64` by default. Changing to `arm64` will reduce costs, but node
+	 * packages that rely on native components may not work without additional
+	 * effort as they will have to be compiled for Arm.
 	 */
-	architecture?: Architecture;
+	architecture?: 'x86_64' | 'arm64';
 }
 
 /**


### PR DESCRIPTION
Adds support for Arm64 architecture in Lambda handlers. X86_64 is used by default, as they were before this PR.

Changing to Arm64 will reduce costs, but node packages that rely on native components may not work without additional effort as they will have to be compiled for Arm. However majority of node packages are javascript-only, so most handlers can switch to Arm with no additional effort.

The support is added using an `architecture` field, which can be defined either in the function definition to pick an architecture for that handler, or in the stack definition `defaults` to set it globally.