### PR TITLE
Allow platform and architecture to be configured

### DIFF
--- a/constructs/base-function.ts
+++ b/constructs/base-function.ts
@@ -8,6 +8,7 @@ import type { FullHandlerDefinition } from '../extract/extract-handlers';
 import { LambdaServiceProps } from './lambda-service';
 import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
 import { HandlerDefinition } from '../handlers/handler';
+import { Architecture, Runtime, RuntimeFamily } from 'aws-cdk-lib/aws-lambda';
 
 export interface BaseFunctionProps<T extends HandlerDefinition> {
 	role: iam.IRole;
@@ -22,6 +23,12 @@ export interface BaseFunctionProps<T extends HandlerDefinition> {
 	};
 	environment?: { [key: string]: string };
 }
+
+const mapArchNameToArchObject = {
+	arm64: Architecture.ARM_64,
+	x86_64: Architecture.X86_64,
+	undefined: undefined,
+};
 
 export class BaseFunction<
 	T extends HandlerDefinition,
@@ -51,6 +58,8 @@ export class BaseFunction<
 		const timeout = cdk.Duration.seconds(
 			definition.timeout ?? defaults?.timeout ?? 30,
 		);
+		const runtime = definition.runtime ?? defaults?.runtime;
+		const architecture = definition.architecture ?? defaults?.architecture;
 
 		super(scope, id, {
 			awsSdkConnectionReuse: true,
@@ -77,6 +86,16 @@ export class BaseFunction<
 			vpc: useVpc ? network?.vpc : undefined,
 			vpcSubnets: useVpc ? network?.vpcSubnets : undefined,
 			securityGroups: useVpc ? network?.securityGroups : undefined,
+			runtime: runtime
+				? new Runtime(runtime, RuntimeFamily.NODEJS, {
+						// This is enabled in AWS CDK built-in runtimes:
+						// https://github.com/aws/aws-cdk/blob/bee883c27eef4840e067806740f4f0f242e7db50/packages/@aws-cdk/aws-lambda/lib/runtime.ts#L82-L92
+						supportsInlineCode: true,
+				  })
+				: undefined,
+			architecture: architecture
+				? mapArchNameToArchObject[architecture]
+				: undefined,
 		});
 
 		this.definition = definition;

--- a/constructs/lambda-service.ts
+++ b/constructs/lambda-service.ts
@@ -31,6 +31,7 @@ import { CfnAuthorizer } from 'aws-cdk-lib/aws-apigatewayv2';
 import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
 import { BaseFunctionProps } from './base-function';
 import { LogRetentionDays } from '../util/log-retention';
+import { HandlerDefinition } from '../handlers';
 
 export interface LambdaServiceProps {
 	/** The path to the folder where the handlers are stored.
@@ -86,6 +87,8 @@ export interface LambdaServiceProps {
 		vpc?: boolean;
 		logRetention?: 'destroy' | 'retain';
 		logRetentionDuration?: LogRetentionDays;
+		runtime?: HandlerDefinition['runtime'];
+		architecture?: HandlerDefinition['architecture'];
 	};
 	/** VPC, subnet, and security groups for the lambda functions.
 	 *

--- a/fixtures/example/api/test-is-duplicate.handler.ts
+++ b/fixtures/example/api/test-is-duplicate.handler.ts
@@ -28,6 +28,8 @@ export const handler = ApiHandler(
 			body: UserSchema,
 		},
 		pathParameters: ['userId'],
+		architecture: 'arm64',
+		runtime: 'nodejs18.x',
 	},
 	async (event) => {
 		console.log(event);

--- a/handlers/handler.ts
+++ b/handlers/handler.ts
@@ -51,6 +51,24 @@ export interface HandlerDefinition {
 	 * How long should logs be kept while the stack is live?
 	 */
 	logRetentionDuration?: LogRetentionDays;
+	/**
+	 * The AWS Lambda runtime to use for functions.
+	 *
+	 * The supported runtimes are listed in the type for convenience. In case
+	 * there are new Nodejs runtimes available, you should be able to pick those
+	 * here as well. Check the AWS Lambda documentation for the supported nodejs
+	 * runtimes: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
+	 *
+	 * Defaults to nodejs14.x if not specified.
+	 */
+	runtime?: 'nodejs14.x' | 'nodejs16.x' | 'nodejs18.x';
+	/**
+	 * The AWS Lambda architecture to use for functions.
+	 *
+	 * Not all code will run out of the box on arm architectures. Code using
+	 * native modules may need to be specifically built for arm.
+	 */
+	architecture?: 'x86_64' | 'arm64';
 }
 
 /**


### PR DESCRIPTION
Allows the platform (nodejs version) and architecture (x86_64 vs arm) to be configured for Lambda functions. The value can be set in the defaults for a whole service, and can be overridden per handler in the handler definition.

The changes are fully backwards compatible. If no options are provided, we won't pass them to the CDK either which should fall back to the same defaults as we had before.