### PR TITLE
Refactor event handler validation

### DIFF
--- a/fixtures/example/event/test-event.handler.ts
+++ b/fixtures/example/event/test-event.handler.ts
@@ -1,4 +1,3 @@
-import { EventBridgeEvent } from 'aws-lambda';
 import { EventHandler } from '../../../handlers';
 
 interface User {
@@ -15,8 +14,15 @@ export const handler = EventHandler(
 		eventBusName: 'event-bus-name',
 		memorySize: 1024,
 		timeout: 900,
-		validator: (body) => {
-			return body as EventBridgeEvent<'Some user was added type', User>;
+		/**
+		 * Deprecated validator
+		 */
+		// validator: (body) => {
+		// 	return body as EventBridgeEvent<'Some user was added type', User>;
+		// },
+		validators: {
+			type: (type) => type as 'Some user was added type',
+			detail: (detail) => detail as User,
 		},
 	},
 	async (event) => {


### PR DESCRIPTION
This change is to keep consistency with `ApiHandler` and how its validator works. Like `ApiHandler`, the `EventHandler` will now split its validation across multiple validators. Currently `type` and `detail` are supported.

## Before
```ts
validator: (body) => body as EventBridgeEvent<'Some user was added type', User>;
```

## After
```ts
validators: {
	type: (type) => type as 'Some user was added type',
	detail: (detail) => detail as User,
},
```