### PR TITLE
Create get jwt claim array value from string fn

### DIFF
--- a/util/get-jwt-claim-array-value-from-string.test.ts
+++ b/util/get-jwt-claim-array-value-from-string.test.ts
@@ -1,0 +1,20 @@
+import { getJwtClaimArrayValueFromString } from './get-jwt-claim-array-value-from-string';
+
+describe('get-jwt-claim-array-value-from-string', () => {
+	it('properly parses out valid claim input', () => {
+		const result = getJwtClaimArrayValueFromString('[1 2 3]');
+
+		console.log(result);
+		expect(result.length).toBe(3);
+		expect(result[0]).toBe('1');
+		expect(result[2]).toBe('3');
+	});
+	it('should throw if value does not appear to be the expected AWS array type', () => {
+		try {
+			getJwtClaimArrayValueFromString('1 2 3');
+		} catch (error) {
+			return expect(true).toBe(true);
+		}
+		expect(true).toBe(false);
+	});
+});

--- a/util/get-jwt-claim-array-value-from-string.ts
+++ b/util/get-jwt-claim-array-value-from-string.ts
@@ -1,0 +1,30 @@
+/**
+ * AWS returns array claims on a JWT in a strange way. If you have an array
+ * like this
+ *
+ * ```json
+ * ["864128384660228893", "698902573331070747", "240098361292620967"]
+ * ```
+ *
+ * You'll get a string that looks like this
+ * ```js
+ * "[864128384660228893 698902573331070747 240098361292620967]"
+ * ```
+ *
+ * with no commas or quotes around the items. This is a simple way to parse
+ * out the values and turn them back into an array.
+ *
+ * It will always be an array of strings, even though the input could
+ * theoretically be anything
+ * @param value string
+ */
+export function getJwtClaimArrayValueFromString(value: string): string[] {
+	const isProperFormat = value.match(/[\[].*[\]]/);
+
+	if (!isProperFormat) {
+		throw new Error('Claim is not the expected AWS array type');
+	}
+
+	let cleanedUpValue = value.replace(/[\[|\]]/g, '');
+	return cleanedUpValue.split(' ');
+}


### PR DESCRIPTION
This PR adds a helper function to get JWT claim array values from the string provided from AWS. I copied this over from Zuck with some minor changes. Seems like we're using this a few places so I figured we could consolidate the logic a bit