### PR TITLE
Expose maxConcurrency in SQS handler options

### DIFF
--- a/constructs/service-queue-function.ts
+++ b/constructs/service-queue-function.ts
@@ -65,6 +65,7 @@ export class ServiceQueueFunction extends BaseFunction<QueueHandlerDefinition> {
 				? cdk.Duration.seconds(definition.maxBatchingWindow)
 				: undefined,
 			reportBatchItemFailures: true,
+			maxConcurrency: definition.maxConcurrency,
 		});
 		this.addEventSource(this.eventSource);
 	}

--- a/handlers/queue-handler.ts
+++ b/handlers/queue-handler.ts
@@ -46,6 +46,11 @@ export interface QueueHandlerDefinition extends HandlerDefinition {
 	 * @default 10
 	 */
 	maximumAttempts?: number;
+
+	/**
+	 * The max number of concurrent invocations for the SQSHandler
+	 */
+	maxConcurrency?: number;
 }
 
 export type QueueHandlerEvent<T> = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@faceteer/cdk",
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"description": "CDK 2.0 constructs and helpers that make composing a Lambda powered service easier.",
 	"main": "index.js",
 	"files": [


### PR DESCRIPTION
I added this to our other cdk packages, but I'd like for it to be available in faceteer if/when we decide we need to use it.