### PR TITLE
Add tag-triggered npm publish workflow (dry run: 8.0.1-alpha.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+# Publishes @faceteer/cdk to npm when a v* tag is pushed.
+# Authenticates via npm Trusted Publishing (OIDC) — no NPM_TOKEN required.
+# See plan: how a release is cut with main protected, and the prerelease convention.
+
+name: Publish
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm (OIDC requires >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Install
+        run: npm install
+
+      - name: Run Jest Tests
+        run: npm test
+        env:
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+          AWS_DEFAULT_REGION: 'us-east-1'
+
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          if [ "$PKG_VERSION" != "$GITHUB_REF_NAME" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match package.json ($PKG_VERSION)" >&2
+            exit 1
+          fi
+
+      - name: Determine dist-tag
+        id: disttag
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          case "$VERSION" in
+            *-alpha*) echo "tag=alpha" >> "$GITHUB_OUTPUT" ;;
+            *-beta*)  echo "tag=beta"  >> "$GITHUB_OUTPUT" ;;
+            *-rc*)    echo "tag=rc"    >> "$GITHUB_OUTPUT" ;;
+            *)        echo "tag=latest" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Publish to npm
+        run: npm publish --tag ${{ steps.disttag.outputs.tag }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@faceteer/cdk",
-	"version": "8.0.0",
+	"version": "8.0.1-alpha.0",
 	"description": "CDK 2.0 constructs and helpers that make composing a Lambda powered service easier.",
 	"main": "index.js",
 	"files": [
@@ -26,6 +26,9 @@
 	},
 	"engines": {
 		"node": ">=20"
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` — publishes `@faceteer/cdk` on any `v*` tag push, authenticating via npm Trusted Publishing (OIDC) so no `NPM_TOKEN` secret is needed. Provenance attestation is automatic.
- Adds `publishConfig.access: public` to `package.json` so scoped-package access is explicit.
- Bumps version to `8.0.1-alpha.0` as a dry run. This goes to the `alpha` dist-tag, leaving `latest` (currently `8.0.0`) untouched.

## How the workflow picks a dist-tag
Derived from the version string:

| Version                | dist-tag |
| ---------------------- | -------- |
| `X.Y.Z`                | `latest` |
| `X.Y.Z-alpha.N`        | `alpha`  |
| `X.Y.Z-beta.N`         | `beta`   |
| `X.Y.Z-rc.N`           | `rc`     |

The workflow also verifies `v${package.json.version}` matches the pushed tag name and refuses to publish if they diverge.

## Test plan
- [ ] Merge this PR.
- [ ] On main, create and push the tag: `git checkout main && git pull && git tag v8.0.1-alpha.0 && git push origin v8.0.1-alpha.0` (or use the Releases UI targeting main).
- [ ] Watch the Publish workflow in the Actions tab.
- [ ] Confirm `npm view @faceteer/cdk dist-tags` shows `alpha: 8.0.1-alpha.0` and `latest: 8.0.0` (unchanged).
- [ ] Confirm the new version page on npmjs.com shows the "Built and signed on GitHub Actions" provenance badge.

A follow-up PR will carry the Node 24 `NotificationHandler` fix from #58 plus a bump to `8.0.1`.