### PR TITLE
Switch publish workflow to Node 24 (dry run 2: 8.0.1-alpha.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,19 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm (OIDC requires >= 11.5.1)
-        run: npm install -g npm@latest
+      - name: Install npm >= 11.5.1 (OIDC requires it)
+        # Self-upgrading the bundled npm (`npm install -g npm@latest`) is known
+        # to break mid-install on GitHub runners ("Cannot find module
+        # 'promise-retry'"). Install into an isolated prefix and prepend to PATH
+        # instead — avoids replacing the running npm.
+        run: |
+          NPM_DIR="$RUNNER_TEMP/npm-latest"
+          mkdir -p "$NPM_DIR"
+          npm install --prefix "$NPM_DIR" --no-save --no-audit --no-fund npm@latest
+          echo "$NPM_DIR/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Show npm version
+        run: npm --version
 
       - name: Install
         run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,22 +18,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 22
+      - name: Use Node.js 24
+        # Node 24 bundles npm 11.x. OIDC Trusted Publishing needs npm >= 11.5.1,
+        # so if the bundled npm is recent enough we avoid a global upgrade step
+        # (which is fragile on GitHub runners). `Show npm version` below makes
+        # the actual bundled version visible in the run log.
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Install npm >= 11.5.1 (OIDC requires it)
-        # Self-upgrading the bundled npm (`npm install -g npm@latest`) is known
-        # to break mid-install on GitHub runners ("Cannot find module
-        # 'promise-retry'"). Install into an isolated prefix and prepend to PATH
-        # instead — avoids replacing the running npm.
-        run: |
-          NPM_DIR="$RUNNER_TEMP/npm-latest"
-          mkdir -p "$NPM_DIR"
-          npm install --prefix "$NPM_DIR" --no-save --no-audit --no-fund npm@latest
-          echo "$NPM_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Show npm version
         run: npm --version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@faceteer/cdk",
-	"version": "8.0.1-alpha.0",
+	"version": "8.0.1-alpha.1",
 	"description": "CDK 2.0 constructs and helpers that make composing a Lambda powered service easier.",
 	"main": "index.js",
 	"files": [


### PR DESCRIPTION
## Summary
The first dry run (`v8.0.1-alpha.0`) failed on `npm install -g npm@latest` — the self-upgrade leaves a half-replaced install on the GitHub runner (`Cannot find module 'promise-retry'`). An earlier commit on this branch worked around it with a prefix install; this PR replaces that with the cleaner fix: run on Node 24, whose bundled npm (11.x) already supports OIDC Trusted Publishing.

Commits will squash-merge as one.

### Changes
- `publish.yml`: `node-version: '24'`, upgrade/prefix steps removed.
- `publish.yml`: adds a `npm --version` step so the bundled version is visible in the run log (if it ever dips below 11.5.1, the publish step will fail with a clear OIDC error and we'll know to pin).
- `package.json`: bumped to `8.0.1-alpha.1` so a fresh tag exercises the updated workflow.

## Test plan
- [ ] Merge (squash).
- [ ] Tag and push: `git checkout main && git pull && git tag v8.0.1-alpha.1 && git push origin v8.0.1-alpha.1`.
- [ ] Watch Publish workflow. Confirm `npm view @faceteer/cdk dist-tags` shows `alpha: 8.0.1-alpha.1` and `latest: 8.0.0` unchanged.
- [ ] Confirm the provenance badge appears on npmjs.com.