### PR TITLE
Fix NotificationHandler for Node 24 Lambda runtime (v8.0.1)

### DIFF
--- a/handlers/notification-handler.ts
+++ b/handlers/notification-handler.ts
@@ -43,34 +43,30 @@ export function NotificationHandler<T = unknown>(
 ): NotificationHandlerWithDefinition {
 	const { validator = defaultValidator, ...definition } = options;
 
-	const wrappedHandler: SNSHandler = async (event, context, callback) => {
+	const wrappedHandler: SNSHandler = async (event, context) => {
 		const notificationEvent: NotificationEvent<T> = {
 			Records: event.Records,
 			InvalidMessages: [],
 			ValidMessages: [],
 		};
-		try {
-			for (const record of event.Records) {
-				try {
-					const validRecord = validator(JSON.parse(record.Sns.Message));
-					notificationEvent.ValidMessages.push({
-						attempts: 0,
-						body: validRecord,
-						messageId: record.Sns.MessageId,
-					});
-				} catch (error) {
-					notificationEvent.InvalidMessages.push({
-						attempts: 0,
-						body: record.Sns.Message,
-						error,
-						messageId: record.Sns.MessageId,
-					});
-				}
+		for (const record of event.Records) {
+			try {
+				const validRecord = validator(JSON.parse(record.Sns.Message));
+				notificationEvent.ValidMessages.push({
+					attempts: 0,
+					body: validRecord,
+					messageId: record.Sns.MessageId,
+				});
+			} catch (error) {
+				notificationEvent.InvalidMessages.push({
+					attempts: 0,
+					body: record.Sns.Message,
+					error,
+					messageId: record.Sns.MessageId,
+				});
 			}
-			await handler(notificationEvent, context);
-		} catch (error) {
-			callback(error as any);
 		}
+		await handler(notificationEvent, context);
 	};
 
 	return Object.assign(wrappedHandler, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@faceteer/cdk",
-	"version": "8.0.1-alpha.1",
+	"version": "8.0.1",
 	"description": "CDK 2.0 constructs and helpers that make composing a Lambda powered service easier.",
 	"main": "index.js",
 	"files": [


### PR DESCRIPTION
## Summary
- Fixes #58 — `NotificationHandler` wrapped an SNS handler with a 3-argument `(event, context, callback)` signature. Node 24's Lambda runtime rejects callback-style handlers at init with `Runtime.CallbackHandlerDeprecated`, even when the callback is never invoked, so any function built with `NotificationHandler` fails immediately on `nodejs24.x`.
- Drops the `callback` parameter and lets promise rejection propagate naturally — the pattern the other wrappers (`QueueHandler`, `EventHandler`, etc.) already use.
- Bumps version to `8.0.1`.

## Test plan
- [ ] Merge (squash).
- [ ] Tag the merge commit on main: `git checkout main && git pull && git tag v8.0.1 && git push origin v8.0.1`.
- [ ] Watch Publish workflow. Confirm `npm view @faceteer/cdk dist-tags` shows `latest: 8.0.1` and `alpha: 8.0.1-alpha.1`.
- [ ] Confirm provenance badge on npmjs.com.
- [ ] In a consumer project using `NotificationHandler`, pin `@faceteer/cdk@8.0.1`, deploy a Lambda on `nodejs24.x`, and confirm cold start succeeds and SNS messages are processed.