### PR TITLE
Add DynamoStreamHandler (v8.1.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 # Publishes @faceteer/cdk to npm when a v* tag is pushed.
 # Authenticates via npm Trusted Publishing (OIDC) — no NPM_TOKEN required.
-# See plan: how a release is cut with main protected, and the prerelease convention.
+# After publish, lifts the matching section out of CHANGELOG.md and uses it as
+# the body of the GitHub Release, so each version has discoverable notes.
+# See CLAUDE.md ("Releasing") for how a release is cut with main protected.
 
 name: Publish
 
@@ -13,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js 24
         # Node 24 bundles npm 11.x. OIDC Trusted Publishing needs npm >= 11.5.1,
         # so if the bundled npm is recent enough we avoid a global upgrade step
         # (which is fragile on GitHub runners). `Show npm version` below makes
         # the actual bundled version visible in the run log.
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -62,3 +64,27 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --tag ${{ steps.disttag.outputs.tag }}
+
+      - name: Extract release notes from CHANGELOG
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { inside=1; next }
+            inside && (/^## \[/ || /^\[[^]]+\]:/) { exit }
+            inside { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "CHANGELOG.md has no section for version $VERSION" >&2
+            exit 1
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          FLAGS=(--title "$GITHUB_REF_NAME" --notes-file release-notes.md)
+          case "$VERSION" in
+            *-alpha*|*-beta*|*-rc*) FLAGS+=(--prerelease) ;;
+          esac
+          gh release create "$GITHUB_REF_NAME" "${FLAGS[@]}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,9 +62,8 @@ jobs:
             *)        echo "tag=latest" >> "$GITHUB_OUTPUT" ;;
           esac
 
-      - name: Publish to npm
-        run: npm publish --tag ${{ steps.disttag.outputs.tag }}
-
+      # Run before publishing so a missing CHANGELOG section for a stable
+      # release aborts the run *before* the irreversible npm publish.
       - name: Extract release notes from CHANGELOG
         run: |
           VERSION="$(node -p "require('./package.json').version")"
@@ -74,9 +73,17 @@ jobs:
             inside { print }
           ' CHANGELOG.md > release-notes.md
           if [ ! -s release-notes.md ]; then
-            echo "CHANGELOG.md has no section for version $VERSION" >&2
-            exit 1
+            if [ "${{ steps.disttag.outputs.tag }}" = "latest" ]; then
+              echo "CHANGELOG.md has no section for stable version $VERSION" >&2
+              exit 1
+            fi
+            # Prereleases (alpha/beta/rc) are often dry-runs without notes; use a
+            # generic body rather than failing the release.
+            echo "Prerelease $GITHUB_REF_NAME — see CHANGELOG.md for details." > release-notes.md
           fi
+
+      - name: Publish to npm
+        run: npm publish --tag ${{ steps.disttag.outputs.tag }}
 
       - name: Create GitHub Release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to `@faceteer/cdk` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+npm dist-tags track the most recent publish in each channel: `latest` points at the newest stable release, `alpha` / `beta` / `rc` at the newest prerelease of that kind.
+
+## [Unreleased]
+
+## [8.1.0] - 2026-06-05
+
+### Added
+
+- **`DynamoStreamHandler`** — a sixth handler type for processing DynamoDB streams. Records pass through raw (images stay in DynamoDB `AttributeValue` form); return a `retry` list to report failed records via partial batch response (handlers must be idempotent, since streams retry by checkpoint). The source table is referenced by name through a new `tables` map on `LambdaService`.
+
+### Infrastructure
+
+- The publish workflow now creates a GitHub Release whose body is the matching `CHANGELOG.md` section, and bumps `actions/checkout` / `actions/setup-node` from v4 to v6.
+
+## [8.0.1] - 2026-04-19
+
+### Fixed
+
+- `NotificationHandler` now works on the Node 24 Lambda runtime ([#62](https://github.com/faceteer/cdk/issues/62)).
+
+### Infrastructure
+
+- Added a tag-triggered npm publish workflow using Trusted Publishing (OIDC), running on Node 24 ([#60](https://github.com/faceteer/cdk/issues/60), [#61](https://github.com/faceteer/cdk/issues/61)).
+
+[unreleased]: https://github.com/faceteer/cdk/compare/v8.1.0...HEAD
+[8.1.0]: https://github.com/faceteer/cdk/compare/v8.0.1...v8.1.0
+[8.0.1]: https://github.com/faceteer/cdk/releases/tag/v8.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Publishing
 - `npm run prepublishOnly` - Automatically runs before publishing (builds the project)
+- Releases are automated — see [Releasing](#releasing) for the full process.
 
 ## Architecture Overview
 
@@ -21,12 +22,13 @@ This is a TypeScript CDK v2 library (`@faceteer/cdk`) that provides constructs a
 
 **LambdaService**: The main construct that orchestrates multiple Lambda functions. It automatically discovers handlers in a specified folder and creates the appropriate AWS resources (API Gateway, SQS queues, SNS topics, EventBridge rules, etc.).
 
-**Handler Types**: The library supports 5 handler types:
+**Handler Types**: The library supports 6 handler types:
 - `ApiHandler` - HTTP API endpoints (GET/POST/PUT/PATCH/DELETE)
 - `QueueHandler` - SQS queue message processing
 - `EventHandler` - EventBridge event processing
 - `CronHandler` - Scheduled Lambda functions
 - `NotificationHandler` - SNS topic subscribers
+- `DynamoStreamHandler` - DynamoDB stream processing (table referenced via the `tables` map on `LambdaService`)
 
 **Handler Discovery**: The `extractHandlers` function automatically scans a directory for files matching the pattern `*.handler.ts` and creates handler definitions based on the exported `handler` object.
 
@@ -39,6 +41,7 @@ This is a TypeScript CDK v2 library (`@faceteer/cdk`) that provides constructs a
 - `ServiceNotificationFunction` - SNS-integrated Lambda
 - `ServiceCronFunction` - EventBridge-scheduled Lambda
 - `ServiceEventFunction` - EventBridge event-triggered Lambda
+- `ServiceDynamoStreamFunction` - DynamoDB stream-triggered Lambda
 
 **handlers/**: Handler factory functions and type definitions
 - Each handler type has validation, path parameter checking, and error handling
@@ -84,3 +87,47 @@ The project uses Jest with TypeScript support:
 - Fixtures in `fixtures/` for testing handler discovery
 - Coverage reporting enabled
 - Snapshot testing for infrastructure
+
+## Releasing
+
+Releases are automated. `.github/workflows/publish.yml` fires on `v*` tag pushes:
+it runs the Jest tests, **verifies the tag matches `package.json` version**,
+publishes to npm with the right dist-tag via npm Trusted Publishing (OIDC — no
+`NPM_TOKEN`), then creates a GitHub Release whose body is the matching
+`CHANGELOG.md` section. Prereleases are flagged with `--prerelease`.
+
+### npm dist-tags
+
+The dist-tag is derived from the version string:
+
+- `X.Y.Z` → `latest`
+- `X.Y.Z-alpha.N` → `alpha`
+- `X.Y.Z-beta.N` → `beta`
+- `X.Y.Z-rc.N` → `rc`
+
+### Cutting a release (LLM-driven)
+
+`main` is protected, so the version bump and changelog land via PR; the tag is
+pushed only after that merges. Run these steps in order — the user reviews the
+CHANGELOG draft before anything is pushed.
+
+1. **Draft the CHANGELOG entry.** Read `git log <last-tag>..HEAD` and group
+   changes under Keep a Changelog sub-headings (`Added` / `Changed` /
+   `Changed (breaking)` / `Fixed` / `Removed` / `Infrastructure`). Reference
+   issue/PR numbers where commit messages mention them. Write the draft into the
+   `## [Unreleased]` block in `CHANGELOG.md`.
+2. **Rename the block.** `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD`, open a
+   fresh empty `## [Unreleased]` above it, and add/refresh the compare-links at
+   the bottom of the file (`[unreleased]` → `compare/vX.Y.Z...HEAD`, and a
+   `[X.Y.Z]` link).
+3. **Bump `package.json` `version`** to `X.Y.Z` (the tag must match exactly, or
+   the workflow fails).
+4. **Sanity-check** the release-notes extractor returns non-empty output:
+
+   ```sh
+   awk -v ver="X.Y.Z" '$0 ~ "^## \\[" ver "\\]" {inside=1; next} inside && (/^## \[/ || /^\[[^]]+\]:/) {exit} inside' CHANGELOG.md
+   ```
+
+5. **Open a PR** with the version bump + CHANGELOG and merge it to `main`.
+6. **Tag the merged commit and push the tag:** `git tag vX.Y.Z && git push origin vX.Y.Z`.
+   The publish workflow takes it from there (publish + GitHub Release).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,9 +92,14 @@ The project uses Jest with TypeScript support:
 
 Releases are automated. `.github/workflows/publish.yml` fires on `v*` tag pushes:
 it runs the Jest tests, **verifies the tag matches `package.json` version**,
-publishes to npm with the right dist-tag via npm Trusted Publishing (OIDC — no
-`NPM_TOKEN`), then creates a GitHub Release whose body is the matching
-`CHANGELOG.md` section. Prereleases are flagged with `--prerelease`.
+extracts the matching `CHANGELOG.md` section, publishes to npm with the right
+dist-tag via npm Trusted Publishing (OIDC — no `NPM_TOKEN`), then creates a
+GitHub Release with those notes. Prereleases are flagged with `--prerelease`.
+
+Notes extraction runs **before** publishing, so a stable release with no
+`CHANGELOG.md` section aborts before anything reaches npm. A prerelease
+(`-alpha`/`-beta`/`-rc`) without a section does not fail — it gets a generic
+release body — so dry-run tags stay frictionless.
 
 ### npm dist-tags
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The main construct that orchestrates multiple Lambda functions. It automatically
 
 ### Handler Types
 
-The library supports 5 handler types, each creating different AWS integrations:
+The library supports 6 handler types, each creating different AWS integrations:
 
 #### 1. ApiHandler - HTTP API endpoints
 Creates Lambda functions integrated with API Gateway for REST endpoints.
@@ -155,6 +155,37 @@ export const handler = NotificationHandler(
 );
 ```
 
+#### 6. DynamoStreamHandler - DynamoDB stream processing
+Creates Lambda functions triggered by a DynamoDB table's stream. The table is
+referenced by name (see [Tables](#tables)); records are passed through raw (images
+stay in DynamoDB `AttributeValue` form).
+
+```typescript
+// src/handlers/user-changed.handler.ts
+import { DynamoStreamHandler } from '@faceteer/cdk';
+
+export const handler = DynamoStreamHandler(
+  {
+    tableName: 'users',
+    startingPosition: 'TRIM_HORIZON',
+  },
+  async (event) => {
+    const failed = [];
+    for (const record of event.Records) {
+      try {
+        console.log(record.eventName, record.dynamodb?.NewImage);
+      } catch (error) {
+        failed.push(record);
+      }
+    }
+    // Report records to retry. DynamoDB streams retry by checkpoint: Lambda
+    // rewinds to the earliest failure and redelivers everything after it, so
+    // your handler must be idempotent.
+    return { retry: failed };
+  }
+);
+```
+
 ### Handler Discovery
 
 The library automatically discovers handlers using the `extractHandlers` function:
@@ -253,6 +284,24 @@ new LambdaService(this, 'MyService', {
   eventBuses: {
     'user-events': EventBus.fromEventBusName(this, 'UserBus', 'user-events'),
     'order-events': new EventBus(this, 'OrderBus'),
+  },
+});
+```
+
+### Tables
+
+Configure the source tables for DynamoStreamHandlers. Each `DynamoStreamHandler`
+references a table by the key used here. The table must have a stream enabled;
+the framework does not create or own the table.
+
+```typescript
+new LambdaService(this, 'MyService', {
+  handlersFolder: './src/handlers',
+  tables: {
+    // key matches `tableName` in the handler definition
+    users: usersTable, // a dynamodb.Table created elsewhere, or
+    // Table.fromTableAttributes(this, 'Users', { tableName, tableStreamArn })
+    // to reference an existing table
   },
 });
 ```

--- a/__tests__/extract/extract-handlers.test.ts
+++ b/__tests__/extract/extract-handlers.test.ts
@@ -92,6 +92,17 @@ describe('Parse Handlers', () => {
 				memorySize: 256,
 			}),
 		});
+
+		expect(handlers.dynamoStream).toEqual({
+			StreamUsers: expect.objectContaining({
+				name: 'StreamUsers',
+				tableName: 'users',
+				startingPosition: 'TRIM_HORIZON',
+				batchSize: 100,
+				memorySize: 1024,
+				timeout: 900,
+			}),
+		});
 	});
 });
 

--- a/__tests__/handlers/dynamo-stream-handler.test.ts
+++ b/__tests__/handlers/dynamo-stream-handler.test.ts
@@ -1,0 +1,97 @@
+import { DynamoDBRecord } from 'aws-lambda';
+import { DynamoStreamHandler } from '../../handlers';
+
+describe('DynamoDB Stream Handler', () => {
+	test('Reports no failures when the handler succeeds', async () => {
+		const internalHandler = jest.fn(async () => {
+			return { retry: [] };
+		});
+
+		const handler = DynamoStreamHandler(
+			{ tableName: 'users', startingPosition: 'TRIM_HORIZON' },
+			internalHandler,
+		);
+
+		const result = await handler(
+			{ Records: [mockRecord('1'), mockRecord('2')] },
+			{} as any,
+			() => {},
+		);
+
+		expect(internalHandler).toHaveBeenCalled();
+		expect(result).toEqual({ batchItemFailures: [] });
+	});
+
+	test('Reports no failures when the handler returns void', async () => {
+		const handler = DynamoStreamHandler(
+			{ tableName: 'users' },
+			async () => {
+				return;
+			},
+		);
+
+		const result = await handler(
+			{ Records: [mockRecord('1')] },
+			{} as any,
+			() => {},
+		);
+
+		expect(result).toEqual({ batchItemFailures: [] });
+	});
+
+	test('Maps retried records to their sequence numbers', async () => {
+		const handler = DynamoStreamHandler(
+			{ tableName: 'users' },
+			async (event) => {
+				// Retry everything except the first record
+				return { retry: event.Records.slice(1) };
+			},
+		);
+
+		const result = await handler(
+			{ Records: [mockRecord('1'), mockRecord('2'), mockRecord('3')] },
+			{} as any,
+			() => {},
+		);
+
+		expect(result).toEqual({
+			batchItemFailures: [{ itemIdentifier: '2' }, { itemIdentifier: '3' }],
+		});
+	});
+
+	test('Reports the whole batch when the handler throws', async () => {
+		jest.spyOn(console, 'error').mockImplementation(() => {});
+
+		const handler = DynamoStreamHandler({ tableName: 'users' }, async () => {
+			throw new Error('boom');
+		});
+
+		const result = await handler(
+			{ Records: [mockRecord('1'), mockRecord('2')] },
+			{} as any,
+			() => {},
+		);
+
+		expect(result).toEqual({
+			batchItemFailures: [{ itemIdentifier: '1' }, { itemIdentifier: '2' }],
+		});
+	});
+
+	/**
+	 * Generate a mock DynamoDB stream record with the given sequence number.
+	 */
+	function mockRecord(sequenceNumber: string): DynamoDBRecord {
+		return {
+			eventID: sequenceNumber,
+			eventName: 'INSERT',
+			eventSource: 'aws:dynamodb',
+			awsRegion: 'us-east-1',
+			dynamodb: {
+				SequenceNumber: sequenceNumber,
+				Keys: { id: { S: sequenceNumber } },
+				NewImage: { id: { S: sequenceNumber } },
+				StreamViewType: 'NEW_AND_OLD_IMAGES',
+			},
+		};
+	}
+});

--- a/__tests__/handlers/dynamo-stream-handler.test.ts
+++ b/__tests__/handlers/dynamo-stream-handler.test.ts
@@ -59,6 +59,32 @@ describe('DynamoDB Stream Handler', () => {
 		});
 	});
 
+	test('Fails the whole batch if a retried record has no sequence number', async () => {
+		jest.spyOn(console, 'error').mockImplementation(() => {});
+
+		const orphan: DynamoDBRecord = {
+			eventName: 'INSERT',
+			eventSource: 'aws:dynamodb',
+			dynamodb: { Keys: { id: { S: 'x' } } }, // no SequenceNumber
+		};
+
+		const handler = DynamoStreamHandler({ tableName: 'users' }, async () => {
+			return { retry: [orphan] };
+		});
+
+		const result = await handler(
+			{ Records: [mockRecord('1'), orphan] },
+			{} as any,
+			() => {},
+		);
+
+		// Subset-reporting could checkpoint past the orphan, so the whole batch
+		// (the records that do have sequence numbers) is failed instead.
+		expect(result).toEqual({
+			batchItemFailures: [{ itemIdentifier: '1' }],
+		});
+	});
+
 	test('Reports the whole batch when the handler throws', async () => {
 		jest.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/__tests__/infrastructure/__snapshots__/infrastructure.test.ts.snap
+++ b/__tests__/infrastructure/__snapshots__/infrastructure.test.ts.snap
@@ -7,6 +7,7 @@ exports[`Create Service Logical Ids remain unchanged 1`] = `
   "ExampleServiceApiCreateUser6E31DB0D",
   "ExampleServiceQueueUpdateUser725EDE63",
   "ExampleServiceEventUserAddedEventB025E55F",
+  "ExampleServiceStreamUsersAFEFD488",
   "ExampleServiceIncomingEmailSendToProcessQueue17229132",
   "ExampleServiceQueuePullsED3940BC",
 ]

--- a/__tests__/infrastructure/dynamo-stream-handler.test.ts
+++ b/__tests__/infrastructure/dynamo-stream-handler.test.ts
@@ -6,25 +6,29 @@ import { EventBus } from 'aws-cdk-lib/aws-events';
 import { Template } from 'aws-cdk-lib/assertions';
 import { LambdaService } from '../../constructs';
 
+const basePath = path.join(__dirname, '../../fixtures/example');
+
 class StreamStack extends Stack {
 	readonly service: LambdaService;
 
-	constructor(scope: Construct, id: string) {
+	constructor(scope: Construct, id: string, opts: { withUsersTable: boolean }) {
 		super(scope, id);
 
-		const basePath = path.join(__dirname, '../../fixtures/example');
+		const usersTable = new Table(this, 'UsersTable', {
+			partitionKey: { name: 'id', type: AttributeType.STRING },
+			stream: StreamViewType.NEW_AND_OLD_IMAGES,
+		});
 
 		this.service = new LambdaService(this, 'StreamService', {
 			handlersFolder: basePath,
 			eventBuses: {
 				'event-bus-name': new EventBus(this, 'ExampleBus'),
 			},
-			tables: {
-				users: new Table(this, 'UsersTable', {
-					partitionKey: { name: 'id', type: AttributeType.STRING },
-					stream: StreamViewType.NEW_AND_OLD_IMAGES,
-				}),
-			},
+			// Either wire the table the fixture references, or a mismatched key
+			// to exercise the resolution error path.
+			tables: opts.withUsersTable
+				? { users: usersTable }
+				: { other: usersTable },
 		});
 	}
 }
@@ -32,13 +36,22 @@ class StreamStack extends Stack {
 describe('DynamoDB stream handler infrastructure', () => {
 	test('creates an event source mapping wired to the table stream', () => {
 		const app = new App();
-		const stack = new StreamStack(app, 'StreamStack');
+		const stack = new StreamStack(app, 'StreamStack', {
+			withUsersTable: true,
+		});
 		const template = Template.fromStack(stack);
 
 		template.hasResourceProperties('AWS::Lambda::EventSourceMapping', {
 			StartingPosition: 'TRIM_HORIZON',
 			FunctionResponseTypes: ['ReportBatchItemFailures'],
 		});
+	});
+
+	test('throws a clear error when the referenced table is not configured', () => {
+		const app = new App();
+		expect(
+			() => new StreamStack(app, 'MissingTableStack', { withUsersTable: false }),
+		).toThrow(/Could not find the table "users"/);
 	});
 });
 

--- a/__tests__/infrastructure/dynamo-stream-handler.test.ts
+++ b/__tests__/infrastructure/dynamo-stream-handler.test.ts
@@ -1,12 +1,12 @@
 import path from 'path';
-import { LambdaService } from '../../constructs';
-import { Construct } from 'constructs';
 import { App, Stack } from 'aws-cdk-lib';
-import { EventBus } from 'aws-cdk-lib/aws-events';
+import { Construct } from 'constructs';
 import { AttributeType, StreamViewType, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { EventBus } from 'aws-cdk-lib/aws-events';
 import { Template } from 'aws-cdk-lib/assertions';
+import { LambdaService } from '../../constructs';
 
-class ExampleStack extends Stack {
+class StreamStack extends Stack {
 	readonly service: LambdaService;
 
 	constructor(scope: Construct, id: string) {
@@ -14,7 +14,7 @@ class ExampleStack extends Stack {
 
 		const basePath = path.join(__dirname, '../../fixtures/example');
 
-		this.service = new LambdaService(this, 'ExampleService', {
+		this.service = new LambdaService(this, 'StreamService', {
 			handlersFolder: basePath,
 			eventBuses: {
 				'event-bus-name': new EventBus(this, 'ExampleBus'),
@@ -29,16 +29,17 @@ class ExampleStack extends Stack {
 	}
 }
 
-const app = new App();
+describe('DynamoDB stream handler infrastructure', () => {
+	test('creates an event source mapping wired to the table stream', () => {
+		const app = new App();
+		const stack = new StreamStack(app, 'StreamStack');
+		const template = Template.fromStack(stack);
 
-describe('Create Service', () => {
-	test('Logical Ids remain unchanged', () => {
-		const stack = new ExampleStack(app, 'ExampleStack');
-
-		const LogicalIds = Object.keys(
-			Template.fromStack(stack).findResources('AWS::Lambda::Function'),
-		);
-
-		expect(LogicalIds).toMatchSnapshot();
+		template.hasResourceProperties('AWS::Lambda::EventSourceMapping', {
+			StartingPosition: 'TRIM_HORIZON',
+			FunctionResponseTypes: ['ReportBatchItemFailures'],
+		});
 	});
 });
+
+export {};

--- a/__tests__/infrastructure/lib/example-api-stack.ts
+++ b/__tests__/infrastructure/lib/example-api-stack.ts
@@ -1,5 +1,6 @@
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { EventBus } from 'aws-cdk-lib/aws-events';
+import { AttributeType, StreamViewType, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
 import { LambdaService } from '../../../constructs';
 
@@ -17,6 +18,12 @@ export class ExampleApiStack extends Stack {
 			eventBuses: {
 				foobar: new EventBus(this, 'testEB', {
 					eventBusName: 'foobar',
+				}),
+			},
+			tables: {
+				users: new Table(this, 'UsersTable', {
+					partitionKey: { name: 'id', type: AttributeType.STRING },
+					stream: StreamViewType.NEW_AND_OLD_IMAGES,
 				}),
 			},
 		});

--- a/constructs/lambda-service.ts
+++ b/constructs/lambda-service.ts
@@ -374,6 +374,10 @@ export class LambdaService extends Construct implements iam.IGrantable {
 				);
 			}
 
+			// Unlike event buses, tables are resolved by map key only. An
+			// `ITable`'s name is often an unresolved token (e.g. when imported
+			// via `Table.fromTableAttributes`), so a name-based fallback like
+			// the event bus loop's would not reliably match.
 			const table = tables[streamHandler.tableName];
 			if (!table) {
 				throw new Error(`

--- a/constructs/lambda-service.ts
+++ b/constructs/lambda-service.ts
@@ -8,6 +8,7 @@ import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as route53Targets from 'aws-cdk-lib/aws-route53-targets';
 import * as events from 'aws-cdk-lib/aws-events';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { constantCase } from 'change-case';
 import { Construct } from 'constructs';
 import { extractHandlers } from '../extract/extract-handlers';
@@ -16,6 +17,7 @@ import { ServiceNotificationFunction } from './service-notification-function';
 import { ServiceQueueFunction } from './service-queue-function';
 import { ServiceCronFunction } from './service-cron-function';
 import { ServiceEventFunction } from './service-event-function';
+import { ServiceDynamoStreamFunction } from './service-dynamo-stream-function';
 import { validatePathParameters } from '../util/validate-path-parameters';
 import {
 	ApiGateway,
@@ -124,6 +126,11 @@ export interface LambdaServiceProps {
 	 * Use the key to reference the appropriate event bus in your Event Handler definition.
 	 */
 	eventBuses?: { [key: string]: events.IEventBus };
+	/**
+	 * Use the key to reference the appropriate table in your DynamoDB Stream
+	 * Handler definition. The table must have a stream enabled.
+	 */
+	tables?: { [key: string]: dynamodb.ITable };
 }
 
 export class LambdaService extends Construct implements iam.IGrantable {
@@ -153,6 +160,7 @@ export class LambdaService extends Construct implements iam.IGrantable {
 			defaultScopes,
 			domain,
 			eventBuses,
+			tables,
 			api,
 			stage,
 			layers,
@@ -233,7 +241,14 @@ export class LambdaService extends Construct implements iam.IGrantable {
 		 */
 		const handlers: ReturnType<typeof extractHandlers> = handlersFolder
 			? extractHandlers(handlersFolder)
-			: { api: {}, notification: {}, queue: {}, cron: {}, event: {} };
+			: {
+					api: {},
+					notification: {},
+					queue: {},
+					cron: {},
+					event: {},
+					dynamoStream: {},
+			  };
 
 		if (domain) {
 			const { certificate, domainName, route53Zone } = domain;
@@ -350,6 +365,33 @@ export class LambdaService extends Construct implements iam.IGrantable {
 				eventBus,
 			});
 			this.functions.push(eventFn);
+		}
+
+		for (const streamHandler of Object.values(handlers.dynamoStream)) {
+			if (!tables) {
+				throw new Error(
+					'Tried to create a DynamoDB stream handler without any configured tables',
+				);
+			}
+
+			const table = tables[streamHandler.tableName];
+			if (!table) {
+				throw new Error(`
+					Could not find the table "${streamHandler.tableName}" referenced by the DynamoDB stream handler "${streamHandler.name}".
+					Please make sure the handler references a table configured in the "tables" property of the service.
+				`);
+			}
+
+			const streamFn = new ServiceDynamoStreamFunction(
+				this,
+				streamHandler.name,
+				{
+					...baseFunctionProps,
+					definition: streamHandler,
+					table,
+				},
+			);
+			this.functions.push(streamFn);
 		}
 
 		for (const notificationHandler of Object.values(handlers.notification)) {

--- a/constructs/service-dynamo-stream-function.ts
+++ b/constructs/service-dynamo-stream-function.ts
@@ -1,0 +1,59 @@
+import * as cdk from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as lambdaEventSources from 'aws-cdk-lib/aws-lambda-event-sources';
+import { Construct } from 'constructs';
+import { DynamoStreamHandlerDefinition } from '../handlers/dynamo-stream-handler';
+import { BaseFunction, BaseFunctionProps } from './base-function';
+
+export interface ServiceDynamoStreamFunctionProps
+	extends BaseFunctionProps<DynamoStreamHandlerDefinition> {
+	table: dynamodb.ITable;
+}
+
+const startingPositions = {
+	TRIM_HORIZON: lambda.StartingPosition.TRIM_HORIZON,
+	LATEST: lambda.StartingPosition.LATEST,
+};
+
+export class ServiceDynamoStreamFunction extends BaseFunction<DynamoStreamHandlerDefinition> {
+	readonly eventSource: lambdaEventSources.DynamoEventSource;
+
+	constructor(
+		scope: Construct,
+		id: string,
+		props: ServiceDynamoStreamFunctionProps,
+	) {
+		const { definition, defaults, table } = props;
+		super(scope, id, {
+			...props,
+			defaults: {
+				timeout: 60,
+				...defaults,
+			},
+			environment: {
+				DD_TAGS: `handler_type:dynamo-stream,handler_name:${definition.name}`,
+				...props.environment,
+			},
+		});
+
+		this.eventSource = new lambdaEventSources.DynamoEventSource(table, {
+			startingPosition:
+				startingPositions[definition.startingPosition ?? 'TRIM_HORIZON'],
+			batchSize: definition.batchSize,
+			maxBatchingWindow: definition.maxBatchingWindow
+				? cdk.Duration.seconds(definition.maxBatchingWindow)
+				: undefined,
+			retryAttempts: definition.retryAttempts,
+			bisectBatchOnError: definition.bisectBatchOnError,
+			parallelizationFactor: definition.parallelizationFactor,
+			maxRecordAge: definition.maxRecordAge
+				? cdk.Duration.seconds(definition.maxRecordAge)
+				: undefined,
+			reportBatchItemFailures: true,
+		});
+		// DynamoEventSource grants the function's role stream-read permissions
+		// on the table when bound.
+		this.addEventSource(this.eventSource);
+	}
+}

--- a/extract/extract-handlers.ts
+++ b/extract/extract-handlers.ts
@@ -5,6 +5,8 @@ import * as path from 'path';
 import {
 	CronHandlerDefinition,
 	CronHandlerWithDefinition,
+	DynamoStreamHandlerDefinition,
+	DynamoStreamHandlerWithDefinition,
 	EventHandlerDefinition,
 	EventHandlerWithDefinition,
 	NotificationHandlerDefinition,
@@ -32,7 +34,8 @@ type AnyHandler =
 	| QueueHandlerWithDefinition<unknown>
 	| EventHandlerWithDefinition<EventBridgeEvent<string, unknown>>
 	| CronHandlerWithDefinition
-	| NotificationHandlerWithDefinition;
+	| NotificationHandlerWithDefinition
+	| DynamoStreamHandlerWithDefinition;
 
 function handlerName(handler: AnyHandler) {
 	switch (handler.type) {
@@ -48,6 +51,8 @@ function handlerName(handler: AnyHandler) {
 			return pascalCase(
 				`${handler.definition.topicName}-${handler.definition.name}`,
 			);
+		case HandlerTypes.DynamoStream:
+			return pascalCase(`Stream ${handler.definition.tableName}`);
 	}
 }
 
@@ -82,12 +87,17 @@ export function extractHandlers(basePath: string) {
 			FullHandlerDefinition<NotificationHandlerDefinition>
 		>;
 		cron: Record<string, FullHandlerDefinition<CronHandlerDefinition>>;
+		dynamoStream: Record<
+			string,
+			FullHandlerDefinition<DynamoStreamHandlerDefinition>
+		>;
 	} = {
 		api: {},
 		queue: {},
 		event: {},
 		notification: {},
 		cron: {},
+		dynamoStream: {},
 	};
 
 	for (const file of files) {

--- a/fixtures/example/dynamo-stream/test-stream.handler.ts
+++ b/fixtures/example/dynamo-stream/test-stream.handler.ts
@@ -1,0 +1,17 @@
+import { DynamoStreamHandler } from '../../../handlers/dynamo-stream-handler';
+
+export const handler = DynamoStreamHandler(
+	{
+		tableName: 'users',
+		startingPosition: 'TRIM_HORIZON',
+		batchSize: 100,
+		memorySize: 1024,
+		timeout: 900,
+	},
+	async (event) => {
+		for (const record of event.Records) {
+			console.log(record.eventName, record.dynamodb?.Keys);
+		}
+		return { retry: [] };
+	},
+);

--- a/handlers/dynamo-stream-handler.ts
+++ b/handlers/dynamo-stream-handler.ts
@@ -146,9 +146,21 @@ export function DynamoStreamHandler(
 			if (!response || response.retry.length === 0) {
 				return { batchItemFailures: [] };
 			}
-			return {
-				batchItemFailures: toBatchItemFailures(response.retry),
-			};
+			const failures = toBatchItemFailures(response.retry);
+			if (failures.length !== response.retry.length) {
+				/**
+				 * A record returned for retry had no sequence number to report.
+				 * Reporting only a subset could checkpoint Lambda past the
+				 * unreported record (streams retry from the lowest reported
+				 * sequence number), so fail the whole batch instead —
+				 * re-processing is recoverable, skipping a record is not.
+				 */
+				console.error(
+					'A record returned for retry is missing a sequence number; failing the entire batch.',
+				);
+				return { batchItemFailures: toBatchItemFailures(event.Records) };
+			}
+			return { batchItemFailures: failures };
 		} catch (error) {
 			console.error(error);
 			/**

--- a/handlers/dynamo-stream-handler.ts
+++ b/handlers/dynamo-stream-handler.ts
@@ -78,12 +78,12 @@ export interface DynamoStreamHandlerDefinition extends HandlerDefinition {
 
 	/**
 	 * The maximum age, in seconds, of a record that Lambda sends to the
-	 * function.
+	 * function. Records older than this are discarded.
 	 *
-	 * Valid Range: 60 to 604,800 (7 days), or -1 for infinite. The DynamoDB
-	 * stream data retention limit is 24 hours regardless of this value.
+	 * Valid Range: 60 to 604,800 (7 days). The DynamoDB stream data retention
+	 * limit is 24 hours regardless of this value.
 	 *
-	 * @default -1 (infinite)
+	 * @default - records are retried until they expire from the stream
 	 */
 	maxRecordAge?: number;
 }

--- a/handlers/dynamo-stream-handler.ts
+++ b/handlers/dynamo-stream-handler.ts
@@ -1,0 +1,168 @@
+import type {
+	DynamoDBBatchItemFailure,
+	DynamoDBRecord,
+	DynamoDBStreamEvent,
+	DynamoDBStreamHandler,
+} from 'aws-lambda';
+import { AsyncHandler, HandlerDefinition, HandlerTypes } from './handler';
+
+export interface DynamoStreamHandlerDefinition extends HandlerDefinition {
+	/**
+	 * The logical name used to reference the source DynamoDB table.
+	 *
+	 * This is a key into the `tables` map configured on the `LambdaService`,
+	 * not a CDK construct. The table itself (with its stream enabled) is
+	 * supplied where the service is created.
+	 */
+	tableName: string;
+
+	/**
+	 * Where to begin reading the stream.
+	 *
+	 * Only `TRIM_HORIZON` and `LATEST` are valid for DynamoDB streams.
+	 * `LATEST` can miss events while the event source mapping is being
+	 * created or updated (stream polling is eventually consistent), so
+	 * `TRIM_HORIZON` is recommended.
+	 *
+	 * @default 'TRIM_HORIZON'
+	 */
+	startingPosition?: 'TRIM_HORIZON' | 'LATEST';
+
+	/**
+	 * The largest number of records that Lambda retrieves from the stream when
+	 * invoking the function.
+	 *
+	 * Valid Range: Minimum value of 1. Maximum value of 10,000.
+	 *
+	 * @default 100
+	 */
+	batchSize?: number;
+
+	/**
+	 * The maximum amount of time, in seconds, to gather records before invoking
+	 * the function.
+	 *
+	 * Valid Range: Minimum value of 0. Maximum value of 300 (5 minutes).
+	 *
+	 * @default - no batching window
+	 */
+	maxBatchingWindow?: number;
+
+	/**
+	 * The maximum number of times to retry a failing batch before the records
+	 * expire or are sent to an on-failure destination.
+	 *
+	 * Valid Range: -1 (infinite) or 0 to 10,000.
+	 *
+	 * @default -1 (infinite, until the record expires in the stream)
+	 */
+	retryAttempts?: number;
+
+	/**
+	 * If the function returns an error, split the batch in two and retry each
+	 * half separately.
+	 *
+	 * @default false
+	 */
+	bisectBatchOnError?: boolean;
+
+	/**
+	 * The number of batches to process from each shard concurrently.
+	 *
+	 * Valid Range: Minimum value of 1. Maximum value of 10. In-order
+	 * processing is still guaranteed per partition (and sort) key.
+	 *
+	 * @default 1
+	 */
+	parallelizationFactor?: number;
+
+	/**
+	 * The maximum age, in seconds, of a record that Lambda sends to the
+	 * function.
+	 *
+	 * Valid Range: 60 to 604,800 (7 days), or -1 for infinite. The DynamoDB
+	 * stream data retention limit is 24 hours regardless of this value.
+	 *
+	 * @default -1 (infinite)
+	 */
+	maxRecordAge?: number;
+}
+
+export type DynamoStreamHandlerEvent = DynamoDBStreamEvent;
+
+/**
+ * Records that failed to process and should be retried.
+ *
+ * DynamoDB streams are ordered and retried by checkpoint: when records are
+ * returned here, Lambda checkpoints to the record with the **lowest** sequence
+ * number and retries **all** records from that point forward. Records that
+ * succeeded but sit after the earliest failure will be delivered again, so the
+ * handler must be idempotent (delivery is at-least-once).
+ */
+export type DynamoStreamHandlerResponse = { retry: DynamoDBRecord[] } | void;
+
+export type DynamoStreamHandlerWithDefinition = DynamoDBStreamHandler & {
+	type: HandlerTypes.DynamoStream;
+	definition: DynamoStreamHandlerDefinition;
+};
+
+/**
+ * Map records to the partial-batch-failure shape Lambda expects.
+ *
+ * The `itemIdentifier` for a DynamoDB stream record is its `SequenceNumber`.
+ * Records without one are skipped (nothing can be reported for them).
+ */
+function toBatchItemFailures(
+	records: DynamoDBRecord[],
+): DynamoDBBatchItemFailure[] {
+	const failures: DynamoDBBatchItemFailure[] = [];
+	for (const record of records) {
+		const sequenceNumber = record.dynamodb?.SequenceNumber;
+		if (sequenceNumber) {
+			failures.push({ itemIdentifier: sequenceNumber });
+		}
+	}
+	return failures;
+}
+
+/**
+ * Create a handler for processing records from a DynamoDB stream.
+ *
+ * Records are passed through raw (images remain in DynamoDB `AttributeValue`
+ * form). Return a `retry` list to report the records that failed; everything
+ * else in the batch is treated as processed. If the handler throws, the entire
+ * batch is reported as failed and retried.
+ *
+ * Because retries are checkpoint based and delivery is at-least-once, the
+ * handler must be idempotent. See {@link DynamoStreamHandlerResponse}.
+ */
+export function DynamoStreamHandler(
+	options: DynamoStreamHandlerDefinition,
+	handler: AsyncHandler<DynamoStreamHandlerEvent, DynamoStreamHandlerResponse>,
+): DynamoStreamHandlerWithDefinition {
+	const wrappedHandler: DynamoDBStreamHandler = async (event, context) => {
+		try {
+			const response = await handler(event, context);
+			if (!response || response.retry.length === 0) {
+				return { batchItemFailures: [] };
+			}
+			return {
+				batchItemFailures: toBatchItemFailures(response.retry),
+			};
+		} catch (error) {
+			console.error(error);
+			/**
+			 * If the handler fails to run we'll mark the whole batch as failed
+			 * so it gets retried from the start.
+			 */
+			return {
+				batchItemFailures: toBatchItemFailures(event.Records),
+			};
+		}
+	};
+
+	return Object.assign(wrappedHandler, {
+		type: HandlerTypes.DynamoStream as const,
+		definition: options,
+	});
+}

--- a/handlers/handler.ts
+++ b/handlers/handler.ts
@@ -90,4 +90,5 @@ export enum HandlerTypes {
 	Queue = 'queue',
 	Event = 'event',
 	Notification = 'notification',
+	DynamoStream = 'dynamoStream',
 }

--- a/handlers/index.ts
+++ b/handlers/index.ts
@@ -1,5 +1,6 @@
 export * from './api-handler';
 export * from './cron-handler';
+export * from './dynamo-stream-handler';
 export * from './event-handler';
 export * from './handler';
 export * from './queue-handler';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@faceteer/cdk",
-	"version": "8.0.1",
+	"version": "8.1.0",
 	"description": "CDK 2.0 constructs and helpers that make composing a Lambda powered service easier.",
 	"main": "index.js",
 	"files": [


### PR DESCRIPTION
## Summary

Adds a sixth handler type, **`DynamoStreamHandler`**, for processing DynamoDB streams, and sets up release infrastructure (CHANGELOG + GitHub Release step). Releases **v8.1.0**.

### `DynamoStreamHandler`
- New handler factory in `handlers/dynamo-stream-handler.ts`. Records pass through **raw** (images stay in DynamoDB `AttributeValue` form — no unmarshalling, no new dependency). Return a `retry` list to report failed records; the wrapper maps each to its `SequenceNumber` for partial batch response. A thrown error fails the whole batch.
- Stream retries are checkpoint-based (Lambda rewinds to the earliest failure), so **handlers must be idempotent** — documented in the factory and README.
- `ServiceDynamoStreamFunction` wires a `DynamoEventSource` with `startingPosition` (default `TRIM_HORIZON`), `batchSize`, `maxBatchingWindow`, `retryAttempts`, `bisectBatchOnError`, `parallelizationFactor`, `maxRecordAge`, and `reportBatchItemFailures: true`.
- The source table is referenced by name via a new **`tables`** map on `LambdaService`, mirroring the existing `eventBuses` pattern. Handler authors write only a string `tableName`; the `ITable` is supplied where the service is created.

Out of scope (deliberately): image unmarshalling, `onFailure` DLQ destination, and `filterCriteria`.

### Release infrastructure
- New `CHANGELOG.md` (Keep a Changelog format), seeded with `8.1.0` and `8.0.1`.
- `publish.yml` now creates a GitHub Release from the matching CHANGELOG section (`contents: write`), and bumps `actions/checkout` / `actions/setup-node` v4 → v6.
- New "Releasing" section in `CLAUDE.md` documenting the cut-a-release process.

## Tests
- Unit tests for the handler wrapper (success / void / partial `{retry}` mapping / throw-fails-batch).
- Extract test asserts the new `dynamoStream` bucket.
- Infra test asserts the `EventSourceMapping` has `StartingPosition: TRIM_HORIZON` and `FunctionResponseTypes: [ReportBatchItemFailures]`; snapshot updated for the one new Lambda.
- `npm run build` clean, all 39 tests pass.

## Releasing after merge
Tag the merge commit: `git tag v8.1.0 && git push origin v8.1.0` → publishes to npm (`latest`) and creates the GitHub Release.